### PR TITLE
CI: extend tests timeout to 20min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ fmt:
 
 .PHONY: test
 test:
-	@go test -v -race "${TEST_PKG}"
+	@go test -v -race -timeout 20m "${TEST_PKG}"
 
 .PHONY: generate-jsons
 generate-jsons:


### PR DESCRIPTION
Go's default timeout for tests is 10 min, increasing as our tests usually takes more time.