### PR TITLE
qbft/ remove SyncHighestRoundChange from Syncer interface

### DIFF
--- a/qbft/instance.go
+++ b/qbft/instance.go
@@ -3,9 +3,11 @@ package qbft
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/bloxapp/ssv-spec/types"
-	"github.com/pkg/errors"
 	"sync"
+
+	"github.com/pkg/errors"
+
+	"github.com/bloxapp/ssv-spec/types"
 )
 
 type ProposedValueCheckF func(data []byte) error
@@ -65,10 +67,6 @@ func (i *Instance) Start(value []byte, height Height) {
 			if err := i.Broadcast(proposal); err != nil {
 				fmt.Printf("%s\n", err.Error())
 			}
-		}
-
-		if err := i.config.GetNetwork().SyncHighestRoundChange(types.MessageIDFromBytes(i.State.ID), i.State.Height); err != nil {
-			fmt.Printf("%s\n", err.Error())
 		}
 	})
 }

--- a/qbft/types.go
+++ b/qbft/types.go
@@ -23,8 +23,6 @@ type Timer interface {
 type Syncer interface {
 	// SyncHighestDecided tries to fetch the highest decided from peers (not blocking)
 	SyncHighestDecided(identifier types.MessageID) error
-	// SyncHighestRoundChange tries to fetch for each committee member the highest round change broadcasted for the specific height from peers (not blocking)
-	SyncHighestRoundChange(identifier types.MessageID, height Height) error
 }
 
 // Network is the interface for networking across QBFT components

--- a/types/testingutils/network.go
+++ b/types/testingutils/network.go
@@ -2,7 +2,6 @@ package testingutils
 
 import (
 	"github.com/bloxapp/ssv-spec/dkg"
-	"github.com/bloxapp/ssv-spec/qbft"
 	"github.com/bloxapp/ssv-spec/types"
 )
 
@@ -43,11 +42,6 @@ func (net *TestingNetwork) StreamDKGBlame(blame *dkg.BlameOutput) error {
 
 func (net *TestingNetwork) SyncHighestDecided(identifier types.MessageID) error {
 	net.SyncHighestDecidedCnt++
-	return nil
-}
-
-func (net *TestingNetwork) SyncHighestRoundChange(identifier types.MessageID, height qbft.Height) error {
-	net.SyncHighestChangeRoundCnt++
 	return nil
 }
 


### PR DESCRIPTION
In https://github.com/bloxapp/ssv/pull/756, `SyncHighestRoundChange` became not used anymore but its implementation is still kept to match the `Syncer` interface (https://github.com/bloxapp/ssv/blob/spec-align-qbft/network/p2p/p2p_sync.go#L49). 

The goal of this PR is to get rid of the `SyncHighestRoundChange` implementation.