### PR TITLE
`MessageID.String`: human-friendly format

### DIFF
--- a/types/messages.go
+++ b/types/messages.go
@@ -49,7 +49,7 @@ func NewMsgID(pk []byte, role BeaconRole) MessageID {
 }
 
 func (msgID MessageID) String() string {
-	return hex.EncodeToString(msgID[:])
+	return hex.EncodeToString(msgID.GetPubKey()) + "-" + msgID.GetRoleType().String()
 }
 
 func MessageIDFromBytes(mid []byte) MessageID {


### PR DESCRIPTION
### Rationale

- More human-friendly `ATTESTER` rather than `00000000`.
- Logs can be easily filtered by public key, role or a combination of both (thanks to dash between them.)

### Change
Previously returned `{PublicKeyHex}{RoleHex}`
Now returns `{PublicKeyHex}-{RoleString}`

### Example
~`917494a7348b314221e4df2b22347bfaee841781fa8b11801418b1454045b8a30065be03983a7667275850e472afcff700000000`~
`917494a7348b314221e4df2b22347bfaee841781fa8b11801418b1454045b8a30065be03983a7667275850e472afcff7-ATTESTER`