### PR TITLE
qbft/ Round validation for consensus messages

### DIFF
--- a/qbft/instance.go
+++ b/qbft/instance.go
@@ -164,7 +164,7 @@ func (i *Instance) BaseMsgValidation(msg *SignedMessage) error {
 			i.State.Share.Committee,
 		)
 	case RoundChangeMsgType:
-		return validRoundChange(i.State, i.config, msg, i.State.Height, msg.Message.Round)
+		return validRoundChange(i.State, i.config, msg, i.State.Height, i.State.Round)
 	default:
 		return errors.New("signed message type not supported")
 	}

--- a/qbft/instance.go
+++ b/qbft/instance.go
@@ -124,6 +124,10 @@ func (i *Instance) BaseMsgValidation(msg *SignedMessage) error {
 		return errors.Wrap(err, "invalid signed message")
 	}
 
+	if msg.Message.Round < i.State.Round {
+		return errors.New("past round")
+	}
+
 	switch msg.Message.MsgType {
 	case ProposalMsgType:
 		return isValidProposal(
@@ -164,7 +168,7 @@ func (i *Instance) BaseMsgValidation(msg *SignedMessage) error {
 			i.State.Share.Committee,
 		)
 	case RoundChangeMsgType:
-		return validRoundChange(i.State, i.config, msg, i.State.Height, i.State.Round)
+		return validRoundChange(i.State, i.config, msg, i.State.Height, msg.Message.Round)
 	default:
 		return errors.New("signed message type not supported")
 	}

--- a/qbft/round_change.go
+++ b/qbft/round_change.go
@@ -211,7 +211,7 @@ func validRoundChange(state *State, config IConfig, signedMsg *SignedMessage, he
 	if signedMsg.Message.Height != height {
 		return errors.New("wrong msg height")
 	}
-	if signedMsg.Message.Round != round {
+	if signedMsg.Message.Round < round {
 		return errors.New("wrong msg round")
 	}
 	if len(signedMsg.GetSigners()) != 1 {

--- a/qbft/round_change.go
+++ b/qbft/round_change.go
@@ -211,7 +211,7 @@ func validRoundChange(state *State, config IConfig, signedMsg *SignedMessage, he
 	if signedMsg.Message.Height != height {
 		return errors.New("wrong msg height")
 	}
-	if signedMsg.Message.Round < round {
+	if signedMsg.Message.Round != round {
 		return errors.New("wrong msg round")
 	}
 	if len(signedMsg.GetSigners()) != 1 {

--- a/qbft/spectest/tests/commit/past_round.go
+++ b/qbft/spectest/tests/commit/past_round.go
@@ -34,6 +34,6 @@ func PastRound() *tests.MsgProcessingSpecTest {
 		Pre:           pre,
 		PostRoot:      "02c53d76bdfa84c573386a7dff3e443f120d441b3086f7d5e3834a5c7e1261ab",
 		InputMessages: msgs,
-		ExpectedError: "invalid signed message: wrong msg round",
+		ExpectedError: "invalid signed message: past round",
 	}
 }

--- a/qbft/spectest/tests/controller/latemsg/late_commit_past_round.go
+++ b/qbft/spectest/tests/controller/latemsg/late_commit_past_round.go
@@ -148,6 +148,6 @@ func LateCommitPastRound() *tests.ControllerSpecTest {
 				ControllerPostRoot: "b0fd6098e01e0bee8cac21654e8a6c0f6a0b0634499146fbb722b9af2c459c2d",
 			},
 		},
-		ExpectedError: "could not process msg: invalid signed message: wrong msg round",
+		ExpectedError: "could not process msg: invalid signed message: past round",
 	}
 }

--- a/qbft/spectest/tests/controller/latemsg/late_prepare_past_round.go
+++ b/qbft/spectest/tests/controller/latemsg/late_prepare_past_round.go
@@ -147,6 +147,6 @@ func LatePreparePastRound() *tests.ControllerSpecTest {
 				ControllerPostRoot: "b0fd6098e01e0bee8cac21654e8a6c0f6a0b0634499146fbb722b9af2c459c2d",
 			},
 		},
-		ExpectedError: "could not process msg: invalid signed message: wrong msg round",
+		ExpectedError: "could not process msg: invalid signed message: past round",
 	}
 }

--- a/qbft/spectest/tests/controller/latemsg/late_proposal_past_round.go
+++ b/qbft/spectest/tests/controller/latemsg/late_proposal_past_round.go
@@ -148,6 +148,6 @@ func LateProposalPastRound() *tests.ControllerSpecTest {
 				ControllerPostRoot: "b0fd6098e01e0bee8cac21654e8a6c0f6a0b0634499146fbb722b9af2c459c2d",
 			},
 		},
-		ExpectedError: "could not process msg: invalid signed message: proposal is not valid with current state",
+		ExpectedError: "could not process msg: invalid signed message: past round",
 	}
 }

--- a/qbft/spectest/tests/controller/latemsg/late_round_change_past_round.go
+++ b/qbft/spectest/tests/controller/latemsg/late_round_change_past_round.go
@@ -126,7 +126,7 @@ func LateRoundChangePastRound() *tests.ControllerSpecTest {
 
 	return &tests.ControllerSpecTest{
 		Name:          "late round change past round",
-		ExpectedError: "could not process msg: invalid signed message: wrong msg round",
+		ExpectedError: "could not process msg: invalid signed message: past round",
 		RunInstanceData: []*tests.RunInstanceData{
 			{
 				InputValue:    []byte{1, 2, 3, 4},

--- a/qbft/spectest/tests/controller/latemsg/late_round_change_past_round.go
+++ b/qbft/spectest/tests/controller/latemsg/late_round_change_past_round.go
@@ -125,7 +125,8 @@ func LateRoundChangePastRound() *tests.ControllerSpecTest {
 	}...)
 
 	return &tests.ControllerSpecTest{
-		Name: "late round change past round",
+		Name:          "late round change past round",
+		ExpectedError: "could not process msg: invalid signed message: wrong msg round",
 		RunInstanceData: []*tests.RunInstanceData{
 			{
 				InputValue:    []byte{1, 2, 3, 4},
@@ -144,8 +145,7 @@ func LateRoundChangePastRound() *tests.ControllerSpecTest {
 							Data:       testingutils.CommitDataBytes([]byte{1, 2, 3, 4}),
 						}),
 				},
-
-				ControllerPostRoot: "bb2e61b20360347bf1c48c31e78069a26c59cfd0e06ada43ba799966b0f8b9fd",
+				ControllerPostRoot: "b0fd6098e01e0bee8cac21654e8a6c0f6a0b0634499146fbb722b9af2c459c2d",
 			},
 		},
 	}

--- a/qbft/spectest/tests/prepare/old_round.go
+++ b/qbft/spectest/tests/prepare/old_round.go
@@ -56,6 +56,6 @@ func OldRound() *tests.MsgProcessingSpecTest {
 		Pre:           pre,
 		PostRoot:      "3a85ee7abc9275684534414a639bd4d968f66bb319214da057a47ab8f9a881b4",
 		InputMessages: msgs,
-		ExpectedError: "invalid signed message: wrong msg round",
+		ExpectedError: "invalid signed message: past round",
 	}
 }

--- a/qbft/spectest/tests/proposal/past_round_prev_not_prepared.go
+++ b/qbft/spectest/tests/proposal/past_round_prev_not_prepared.go
@@ -51,6 +51,6 @@ func PastRoundProposalPrevNotPrepared() *tests.MsgProcessingSpecTest {
 		PostRoot:       "36ff2e09d3d5f31610fefda7e7193fc190ebea5bd058b5a163f0c9fd7e5d78e0",
 		InputMessages:  msgs,
 		OutputMessages: []*qbft.SignedMessage{},
-		ExpectedError:  "invalid signed message: proposal is not valid with current state",
+		ExpectedError:  "invalid signed message: past round",
 	}
 }

--- a/qbft/spectest/tests/proposal/past_round_prev_prepared.go
+++ b/qbft/spectest/tests/proposal/past_round_prev_prepared.go
@@ -75,6 +75,6 @@ func PastRoundProposalPrevPrepared() *tests.MsgProcessingSpecTest {
 		PostRoot:       "36ff2e09d3d5f31610fefda7e7193fc190ebea5bd058b5a163f0c9fd7e5d78e0",
 		InputMessages:  msgs,
 		OutputMessages: []*qbft.SignedMessage{},
-		ExpectedError:  "invalid signed message: proposal is not valid with current state",
+		ExpectedError:  "invalid signed message: past round",
 	}
 }

--- a/qbft/spectest/tests/roundchange/justification_past_round.go
+++ b/qbft/spectest/tests/roundchange/justification_past_round.go
@@ -88,6 +88,6 @@ func JustificationPastRound() *tests.MsgProcessingSpecTest {
 		PostRoot:       "6299a16f1fe3598081fd168b8a9e5d46234a680b6af0f8c73ce4d8ec317d64a0",
 		InputMessages:  msgs,
 		OutputMessages: []*qbft.SignedMessage{},
-		ExpectedError:  "invalid signed message: wrong msg round",
+		ExpectedError:  "invalid signed message: past round",
 	}
 }

--- a/qbft/spectest/tests/roundchange/justification_past_round.go
+++ b/qbft/spectest/tests/roundchange/justification_past_round.go
@@ -85,8 +85,9 @@ func JustificationPastRound() *tests.MsgProcessingSpecTest {
 	return &tests.MsgProcessingSpecTest{
 		Name:           "round change past round quorum",
 		Pre:            pre,
-		PostRoot:       "bef19d077666c2831a3582b3fa5bff7af77b17772b14b97827b79ee0994411a5",
+		PostRoot:       "6299a16f1fe3598081fd168b8a9e5d46234a680b6af0f8c73ce4d8ec317d64a0",
 		InputMessages:  msgs,
 		OutputMessages: []*qbft.SignedMessage{},
+		ExpectedError:  "invalid signed message: wrong msg round",
 	}
 }

--- a/qbft/spectest/tests/roundchange/past_round.go
+++ b/qbft/spectest/tests/roundchange/past_round.go
@@ -63,8 +63,9 @@ func PastRound() *tests.MsgProcessingSpecTest {
 	return &tests.MsgProcessingSpecTest{
 		Name:           "round change past round",
 		Pre:            pre,
-		PostRoot:       "76290e82be38ed177a3084e880b32968930b58c2c803093b0d56230b7c2fa0a2",
+		PostRoot:       "6299a16f1fe3598081fd168b8a9e5d46234a680b6af0f8c73ce4d8ec317d64a0",
 		InputMessages:  msgs,
 		OutputMessages: []*qbft.SignedMessage{},
+		ExpectedError:  "invalid signed message: wrong msg round",
 	}
 }

--- a/qbft/spectest/tests/roundchange/past_round.go
+++ b/qbft/spectest/tests/roundchange/past_round.go
@@ -66,6 +66,6 @@ func PastRound() *tests.MsgProcessingSpecTest {
 		PostRoot:       "6299a16f1fe3598081fd168b8a9e5d46234a680b6af0f8c73ce4d8ec317d64a0",
 		InputMessages:  msgs,
 		OutputMessages: []*qbft.SignedMessage{},
-		ExpectedError:  "invalid signed message: wrong msg round",
+		ExpectedError:  "invalid signed message: past round",
 	}
 }


### PR DESCRIPTION
Fail base msg validation (instance) in case we notice a message with past round, before doing a more extensive validation.