### PR TITLE
Slashing protection Fix

### DIFF
--- a/ssv/runner_signatures.go
+++ b/ssv/runner_signatures.go
@@ -20,7 +20,7 @@ func (b *BaseRunner) signBeaconObject(
 		return nil, errors.Wrap(err, "could not get beacon domain")
 	}
 
-	sig, r, err := runner.GetSigner().SignBeaconObject(obj, domain, runner.GetBaseRunner().Share.SharePubKey, runner.GetBaseRunner().BeaconRoleType)
+	sig, r, err := runner.GetSigner().SignBeaconObject(obj, domain, runner.GetBaseRunner().Share.SharePubKey, domainType)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not sign beacon object")
 	}

--- a/ssv/spectest/tests/runner/preconsensus/valid_msg.go
+++ b/ssv/spectest/tests/runner/preconsensus/valid_msg.go
@@ -66,7 +66,7 @@ func ValidMessage() *tests.MultiMsgProcessingSpecTest {
 				Runner: testingutils.AttesterRunner(ks),
 				Duty:   testingutils.TestingAttesterDuty,
 				Messages: []*types.SSVMessage{
-					testingutils.SSVMsgAttester(nil, testingutils.PreConsensusFailedMsg(ks.Shares[1], 1, types.BNRoleAttester)),
+					testingutils.SSVMsgAttester(nil, testingutils.PreConsensusFailedMsg(ks.Shares[1], 1)),
 				},
 				PostDutyRunnerStateRoot: "27a84d7d33b8851a5b0e241280ddb160049768179c74295cb9c35fb875fe44e7",
 				OutputMessages:          []*ssv.SignedPartialSignatureMessage{},
@@ -77,7 +77,7 @@ func ValidMessage() *tests.MultiMsgProcessingSpecTest {
 				Runner: testingutils.SyncCommitteeRunner(ks),
 				Duty:   testingutils.TestingSyncCommitteeDuty,
 				Messages: []*types.SSVMessage{
-					testingutils.SSVMsgSyncCommittee(nil, testingutils.PreConsensusFailedMsg(ks.Shares[1], 1, types.BNRoleSyncCommittee)),
+					testingutils.SSVMsgSyncCommittee(nil, testingutils.PreConsensusFailedMsg(ks.Shares[1], 1)),
 				},
 				PostDutyRunnerStateRoot: "2c4a3a6aa312f25fdb6eef98fc9036eb3db007c6a4a05f3e6137737189acce49",
 				OutputMessages:          []*ssv.SignedPartialSignatureMessage{},

--- a/types/signer.go
+++ b/types/signer.go
@@ -31,7 +31,7 @@ var (
 
 type BeaconSigner interface {
 	// SignBeaconObject returns signature and root.
-	SignBeaconObject(obj ssz.HashRoot, domain spec.Domain, pk []byte, role BeaconRole) (Signature, []byte, error)
+	SignBeaconObject(obj ssz.HashRoot, domain spec.Domain, pk []byte, domainType spec.DomainType) (Signature, []byte, error)
 	// IsAttestationSlashable returns error if attestation is slashable
 	IsAttestationSlashable(pk []byte, data *spec.AttestationData) error
 	// IsBeaconBlockSlashable returns error if the given block is slashable

--- a/types/testingutils/beacon_node.go
+++ b/types/testingutils/beacon_node.go
@@ -17,10 +17,9 @@ var signBeaconObject = func(
 	obj ssz.HashRoot,
 	domainType spec.DomainType,
 	ks *TestKeySet,
-	role types.BeaconRole,
 ) spec.BLSSignature {
 	domain, _ := NewTestingBeaconNode().DomainData(1, domainType)
-	ret, _, _ := NewTestingKeyManager().SignBeaconObject(obj, domain, ks.ValidatorPK.Serialize(), role)
+	ret, _, _ := NewTestingKeyManager().SignBeaconObject(obj, domain, ks.ValidatorPK.Serialize(), domainType)
 
 	blsSig := spec.BLSSignature{}
 	copy(blsSig[:], ret)
@@ -56,7 +55,7 @@ var TestingSignedAttestation = func(ks *TestKeySet) *spec.Attestation {
 	aggregationBitfield.SetBitAt(TestingAttesterDuty.ValidatorCommitteeIndex, true)
 	return &spec.Attestation{
 		Data:            TestingAttestationData,
-		Signature:       signBeaconObject(TestingAttestationData, types.DomainAttester, ks, types.BNRoleAttester),
+		Signature:       signBeaconObject(TestingAttestationData, types.DomainAttester, ks),
 		AggregationBits: aggregationBitfield,
 	}
 }
@@ -171,7 +170,7 @@ var TestingWrongBeaconBlock = func() *bellatrix.BeaconBlock {
 var TestingSignedBeaconBlock = func(ks *TestKeySet) *bellatrix.SignedBeaconBlock {
 	return &bellatrix.SignedBeaconBlock{
 		Message:   TestingBeaconBlock,
-		Signature: signBeaconObject(TestingBeaconBlock, types.DomainProposer, ks, types.BNRoleProposer),
+		Signature: signBeaconObject(TestingBeaconBlock, types.DomainProposer, ks),
 	}
 }
 
@@ -200,7 +199,7 @@ var TestingWrongAggregateAndProof = func() *spec.AggregateAndProof {
 var TestingSignedAggregateAndProof = func(ks *TestKeySet) *spec.SignedAggregateAndProof {
 	return &spec.SignedAggregateAndProof{
 		Message:   TestingAggregateAndProof,
-		Signature: signBeaconObject(TestingAggregateAndProof, types.DomainAggregateAndProof, ks, types.BNRoleAggregator),
+		Signature: signBeaconObject(TestingAggregateAndProof, types.DomainAggregateAndProof, ks),
 	}
 }
 
@@ -221,7 +220,7 @@ var TestingSignedSyncCommitteeBlockRoot = func(ks *TestKeySet) *altair.SyncCommi
 		Slot:            TestingDutySlot,
 		BeaconBlockRoot: TestingSyncCommitteeBlockRoot,
 		ValidatorIndex:  TestingValidatorIndex,
-		Signature:       signBeaconObject(types.SSZBytes(TestingSyncCommitteeBlockRoot[:]), types.DomainSyncCommittee, ks, types.BNRoleSyncCommittee),
+		Signature:       signBeaconObject(types.SSZBytes(TestingSyncCommitteeBlockRoot[:]), types.DomainSyncCommittee, ks),
 	}
 }
 
@@ -276,7 +275,7 @@ var TestingSignedSyncCommitteeContributions = func(
 	}
 	return &altair.SignedContributionAndProof{
 		Message:   msg,
-		Signature: signBeaconObject(msg, types.DomainContributionAndProof, ks, types.BNRoleSyncCommitteeContribution),
+		Signature: signBeaconObject(msg, types.DomainContributionAndProof, ks),
 	}
 }
 

--- a/types/testingutils/keymanager.go
+++ b/types/testingutils/keymanager.go
@@ -102,7 +102,7 @@ func (km *testingKeyManager) IsBeaconBlockSlashable(pk []byte, block *bellatrix.
 	return nil
 }
 
-func (km *testingKeyManager) SignBeaconObject(obj ssz.HashRoot, domain spec.Domain, pk []byte, role types.BeaconRole) (types.Signature, []byte, error) {
+func (km *testingKeyManager) SignBeaconObject(obj ssz.HashRoot, domain spec.Domain, pk []byte, domainType spec.DomainType) (types.Signature, []byte, error) {
 	if k, found := km.keys[hex.EncodeToString(pk)]; found {
 		r, err := types.ComputeETHSigningRoot(obj, domain)
 		if err != nil {

--- a/types/testingutils/ssv_msgs.go
+++ b/types/testingutils/ssv_msgs.go
@@ -201,10 +201,10 @@ var postConsensusAttestationMsg = func(
 		attData = TestingWrongAttestationData
 	}
 
-	signed, root, _ := signer.SignBeaconObject(attData, d, sk.GetPublicKey().Serialize(), types.BNRoleAttester)
+	signed, root, _ := signer.SignBeaconObject(attData, d, sk.GetPublicKey().Serialize(), types.DomainAttester)
 
 	if wrongBeaconSig {
-		signed, _, _ = signer.SignBeaconObject(attData, d, Testing7SharesSet().ValidatorPK.Serialize(), types.BNRoleAttester)
+		signed, _, _ = signer.SignBeaconObject(attData, d, Testing7SharesSet().ValidatorPK.Serialize(), types.DomainAttester)
 	}
 
 	msgs := ssv.PartialSignatureMessages{
@@ -289,9 +289,9 @@ var postConsensusBeaconBlockMsg = func(
 	}
 
 	d, _ := beacon.DomainData(1, types.DomainProposer) // epoch doesn't matter here, hard coded
-	sig, root, _ := signer.SignBeaconObject(block, d, sk.GetPublicKey().Serialize(), types.BNRoleProposer)
+	sig, root, _ := signer.SignBeaconObject(block, d, sk.GetPublicKey().Serialize(), types.DomainProposer)
 	if wrongBeaconSig {
-		sig, root, _ = signer.SignBeaconObject(block, d, Testing7SharesSet().ValidatorPK.Serialize(), types.BNRoleProposer)
+		sig, root, _ = signer.SignBeaconObject(block, d, Testing7SharesSet().ValidatorPK.Serialize(), types.DomainProposer)
 	}
 	blsSig := spec.BLSSignature{}
 	copy(blsSig[:], sig)
@@ -319,11 +319,11 @@ var postConsensusBeaconBlockMsg = func(
 	}
 }
 
-var PreConsensusFailedMsg = func(msgSigner *bls.SecretKey, msgSignerID types.OperatorID, role types.BeaconRole) *ssv.SignedPartialSignatureMessage {
+var PreConsensusFailedMsg = func(msgSigner *bls.SecretKey, msgSignerID types.OperatorID) *ssv.SignedPartialSignatureMessage {
 	signer := NewTestingKeyManager()
 	beacon := NewTestingBeaconNode()
 	d, _ := beacon.DomainData(TestingDutyEpoch, types.DomainRandao)
-	signed, root, _ := signer.SignBeaconObject(types.SSZUint64(TestingDutyEpoch), d, msgSigner.GetPublicKey().Serialize(), role)
+	signed, root, _ := signer.SignBeaconObject(types.SSZUint64(TestingDutyEpoch), d, msgSigner.GetPublicKey().Serialize(), types.DomainRandao)
 
 	msg := ssv.PartialSignatureMessages{
 		Type: ssv.RandaoPartialSig,
@@ -380,7 +380,7 @@ var PreConsensusRandaoDifferentSignerMsg = func(
 	signer := NewTestingKeyManager()
 	beacon := NewTestingBeaconNode()
 	d, _ := beacon.DomainData(TestingDutyEpoch, types.DomainRandao)
-	signed, root, _ := signer.SignBeaconObject(types.SSZUint64(TestingDutyEpoch), d, randaoSigner.GetPublicKey().Serialize(), types.BNRoleProposer)
+	signed, root, _ := signer.SignBeaconObject(types.SSZUint64(TestingDutyEpoch), d, randaoSigner.GetPublicKey().Serialize(), types.DomainRandao)
 
 	msg := ssv.PartialSignatureMessages{
 		Type: ssv.RandaoPartialSig,
@@ -411,9 +411,9 @@ var randaoMsg = func(
 	signer := NewTestingKeyManager()
 	beacon := NewTestingBeaconNode()
 	d, _ := beacon.DomainData(epoch, types.DomainRandao)
-	signed, root, _ := signer.SignBeaconObject(types.SSZUint64(epoch), d, sk.GetPublicKey().Serialize(), types.BNRoleProposer)
+	signed, root, _ := signer.SignBeaconObject(types.SSZUint64(epoch), d, sk.GetPublicKey().Serialize(), types.DomainRandao)
 	if wrongBeaconSig {
-		signed, root, _ = signer.SignBeaconObject(types.SSZUint64(TestingDutyEpoch), d, Testing7SharesSet().ValidatorPK.Serialize(), types.BNRoleProposer)
+		signed, root, _ = signer.SignBeaconObject(types.SSZUint64(TestingDutyEpoch), d, Testing7SharesSet().ValidatorPK.Serialize(), types.DomainRandao)
 	}
 
 	msgs := ssv.PartialSignatureMessages{
@@ -481,9 +481,9 @@ var selectionProofMsg = func(
 	signer := NewTestingKeyManager()
 	beacon := NewTestingBeaconNode()
 	d, _ := beacon.DomainData(1, types.DomainSelectionProof)
-	signed, root, _ := signer.SignBeaconObject(types.SSZUint64(slot), d, beaconsk.GetPublicKey().Serialize(), types.BNRoleAggregator)
+	signed, root, _ := signer.SignBeaconObject(types.SSZUint64(slot), d, beaconsk.GetPublicKey().Serialize(), types.DomainSelectionProof)
 	if wrongBeaconSig {
-		signed, root, _ = signer.SignBeaconObject(types.SSZUint64(slot), d, Testing7SharesSet().ValidatorPK.Serialize(), types.BNRoleAggregator)
+		signed, root, _ = signer.SignBeaconObject(types.SSZUint64(slot), d, Testing7SharesSet().ValidatorPK.Serialize(), types.DomainSelectionProof)
 	}
 
 	_msgs := make([]*ssv.PartialSignatureMessage, 0)
@@ -535,12 +535,12 @@ var validatorRegistrationMsg = func(
 	beacon := NewTestingBeaconNode()
 	d, _ := beacon.DomainData(epoch, types.DomainApplicationBuilder)
 
-	signed, root, _ := signer.SignBeaconObject(TestingValidatorRegistration, d, beaconSK.GetPublicKey().Serialize(), types.BNRoleValidatorRegistration)
+	signed, root, _ := signer.SignBeaconObject(TestingValidatorRegistration, d, beaconSK.GetPublicKey().Serialize(), types.DomainApplicationBuilder)
 	if wrongRoot {
-		signed, root, _ = signer.SignBeaconObject(TestingValidatorRegistrationWrong, d, beaconSK.GetPublicKey().Serialize(), types.BNRoleValidatorRegistration)
+		signed, root, _ = signer.SignBeaconObject(TestingValidatorRegistrationWrong, d, beaconSK.GetPublicKey().Serialize(), types.DomainApplicationBuilder)
 	}
 	if wrongBeaconSig {
-		signed, root, _ = signer.SignBeaconObject(TestingValidatorRegistration, d, Testing7SharesSet().ValidatorPK.Serialize(), types.BNRoleValidatorRegistration)
+		signed, root, _ = signer.SignBeaconObject(TestingValidatorRegistration, d, Testing7SharesSet().ValidatorPK.Serialize(), types.DomainApplicationBuilder)
 	}
 
 	msgs := ssv.PartialSignatureMessages{
@@ -638,9 +638,9 @@ var postConsensusAggregatorMsg = func(
 		aggData = TestingWrongAggregateAndProof
 	}
 
-	signed, root, _ := signer.SignBeaconObject(aggData, d, sk.GetPublicKey().Serialize(), types.BNRoleAggregator)
+	signed, root, _ := signer.SignBeaconObject(aggData, d, sk.GetPublicKey().Serialize(), types.DomainAggregateAndProof)
 	if wrongBeaconSig {
-		signed, root, _ = signer.SignBeaconObject(aggData, d, Testing7SharesSet().ValidatorPK.Serialize(), types.BNRoleAggregator)
+		signed, root, _ = signer.SignBeaconObject(aggData, d, Testing7SharesSet().ValidatorPK.Serialize(), types.DomainAggregateAndProof)
 	}
 
 	msgs := ssv.PartialSignatureMessages{
@@ -723,9 +723,9 @@ var postConsensusSyncCommitteeMsg = func(
 	if wrongRoot {
 		blockRoot = TestingSyncCommitteeWrongBlockRoot
 	}
-	signed, root, _ := signer.SignBeaconObject(types.SSZBytes(blockRoot[:]), d, sk.GetPublicKey().Serialize(), types.BNRoleSyncCommittee)
+	signed, root, _ := signer.SignBeaconObject(types.SSZBytes(blockRoot[:]), d, sk.GetPublicKey().Serialize(), types.DomainSyncCommittee)
 	if wrongBeaconSig {
-		signed, root, _ = signer.SignBeaconObject(types.SSZBytes(blockRoot[:]), d, Testing7SharesSet().ValidatorPK.Serialize(), types.BNRoleSyncCommittee)
+		signed, root, _ = signer.SignBeaconObject(types.SSZBytes(blockRoot[:]), d, Testing7SharesSet().ValidatorPK.Serialize(), types.DomainSyncCommittee)
 	}
 
 	msgs := ssv.PartialSignatureMessages{
@@ -819,9 +819,9 @@ var contributionProofMsg = func(
 			Slot:              slot,
 			SubcommitteeIndex: subnet,
 		}
-		sig, root, _ := signer.SignBeaconObject(data, d, beaconsk.GetPublicKey().Serialize(), types.BNRoleSyncCommitteeContribution)
+		sig, root, _ := signer.SignBeaconObject(data, d, beaconsk.GetPublicKey().Serialize(), types.DomainSyncCommitteeSelectionProof)
 		if wrongBeaconSig {
-			sig, root, _ = signer.SignBeaconObject(data, d, Testing7SharesSet().ValidatorPK.Serialize(), types.BNRoleSyncCommitteeContribution)
+			sig, root, _ = signer.SignBeaconObject(data, d, Testing7SharesSet().ValidatorPK.Serialize(), types.DomainSyncCommitteeSelectionProof)
 		}
 
 		msg := &ssv.PartialSignatureMessage{
@@ -932,7 +932,7 @@ var postConsensusSyncCommitteeContributionMsg = func(
 		}
 		dProof, _ := beacon.DomainData(1, types.DomainSyncCommitteeSelectionProof)
 
-		proofSig, _, _ := signer.SignBeaconObject(data, dProof, keySet.ValidatorPK.Serialize(), types.BNRoleSyncCommitteeContribution)
+		proofSig, _, _ := signer.SignBeaconObject(data, dProof, keySet.ValidatorPK.Serialize(), types.DomainSyncCommitteeSelectionProof)
 		blsProofSig := spec.BLSSignature{}
 		copy(blsProofSig[:], proofSig)
 
@@ -946,9 +946,9 @@ var postConsensusSyncCommitteeContributionMsg = func(
 			SelectionProof:  blsProofSig,
 		}
 
-		signed, root, _ := signer.SignBeaconObject(contribAndProof, dContribAndProof, sk.GetPublicKey().Serialize(), types.BNRoleSyncCommitteeContribution)
+		signed, root, _ := signer.SignBeaconObject(contribAndProof, dContribAndProof, sk.GetPublicKey().Serialize(), types.DomainSyncCommitteeSelectionProof)
 		if wrongBeaconSig {
-			signed, root, _ = signer.SignBeaconObject(contribAndProof, dContribAndProof, Testing7SharesSet().ValidatorPK.Serialize(), types.BNRoleSyncCommitteeContribution)
+			signed, root, _ = signer.SignBeaconObject(contribAndProof, dContribAndProof, Testing7SharesSet().ValidatorPK.Serialize(), types.DomainSyncCommitteeSelectionProof)
 		}
 
 		msg := &ssv.PartialSignatureMessage{


### PR DESCRIPTION
Pass domain type to SignBeaconObject func instead of the role

the bug:
- passing the beacon role type to the SignBeaconObject function misleads the dynamic check for slashing protection.
   e.g. passing BNRoleProposer for Randao