### PR TITLE
Fix checks if H(data) != root

### DIFF
--- a/qbft/decided.go
+++ b/qbft/decided.go
@@ -79,7 +79,7 @@ func ValidateDecided(
 		return errors.Wrap(err, "could not hash input data")
 	}
 	if !bytes.Equal(r[:], signedDecided.Message.Root[:]) {
-		return errors.Wrap(err, "H(data) != root")
+		return errors.New("H(data) != root")
 	}
 
 	return nil

--- a/qbft/proposal.go
+++ b/qbft/proposal.go
@@ -77,7 +77,7 @@ func isValidProposal(
 		return errors.Wrap(err, "could not hash input data")
 	}
 	if !bytes.Equal(signedProposal.Message.Root[:], r[:]) {
-		return errors.Wrap(err, "H(data) != root")
+		return errors.New("H(data) != root")
 	}
 
 	// get justifications

--- a/qbft/round_change.go
+++ b/qbft/round_change.go
@@ -244,7 +244,7 @@ func validRoundChange(state *State, config IConfig, signedMsg *SignedMessage, he
 		}
 
 		if !bytes.Equal(r[:], signedMsg.Message.Root[:]) {
-			return errors.Wrap(err, "H(data) != root")
+			return errors.New("H(data) != root")
 		}
 
 		if !HasQuorum(state.Share, prepareMsgs) {


### PR DESCRIPTION
In all cases of `errors.Wrap(err, "H(data) != root")` `err` is always `nil` (the result of `HashDataRoot`), so `errors.Wrap` always returns `nil` according to https://pkg.go.dev/github.com/pkg/errors#Wrap