### PR TITLE
testingutils: don't ignore encoding errors

### DIFF
--- a/types/testingutils/ssv_msgs.go
+++ b/types/testingutils/ssv_msgs.go
@@ -119,12 +119,19 @@ var SSVMsgValidatorRegistration = func(qbftMsg *qbft.SignedMessage, partialSigMs
 var ssvMsg = func(qbftMsg *qbft.SignedMessage, postMsg *ssv.SignedPartialSignatureMessage, msgID types.MessageID) *types.SSVMessage {
 	var msgType types.MsgType
 	var data []byte
+	var err error
 	if qbftMsg != nil {
 		msgType = types.SSVConsensusMsgType
-		data, _ = qbftMsg.Encode()
+		data, err = qbftMsg.Encode()
+		if err != nil {
+			panic(err)
+		}
 	} else if postMsg != nil {
 		msgType = types.SSVPartialSignatureMsgType
-		data, _ = postMsg.Encode()
+		data, err = postMsg.Encode()
+		if err != nil {
+			panic(err)
+		}
 	} else {
 		panic("msg type undefined")
 	}


### PR DESCRIPTION
Since SSZ validates the data before encoding, it can return errors where JSON wouldn't have.

For example, I spent an hour not realizing why tests fail, and finally found out that we were ignoring an encoding error:

```
SignedMessage.Signature (bytes array does not have the correct length): expected 96 and 4 found
```

This PR just panics instead of returns because these errors should only happen when editing/writing tests.
