### PR TITLE
Issue C: Missing Tests Could Lead to Incorrect Implementations

### DIFF
--- a/qbft/spectest/tests/commit/no_commit_quorum.go
+++ b/qbft/spectest/tests/commit/no_commit_quorum.go
@@ -1,0 +1,34 @@
+package commit
+
+import (
+	"github.com/bloxapp/ssv-spec/qbft"
+	"github.com/bloxapp/ssv-spec/qbft/spectest/tests"
+	"github.com/bloxapp/ssv-spec/types/testingutils"
+)
+
+// NoCommitQuorum tests the state of the QBFT instance when received commit messages don't create a quorum
+func NoCommitQuorum() tests.SpecTest {
+	pre := testingutils.BaseInstance()
+	ks := testingutils.Testing4SharesSet()
+
+	msgs := []*qbft.SignedMessage{
+		testingutils.TestingProposalMessage(ks.Shares[1], 1),
+
+		testingutils.TestingPrepareMessage(ks.Shares[1], 1),
+		testingutils.TestingPrepareMessage(ks.Shares[2], 2),
+		testingutils.TestingPrepareMessage(ks.Shares[3], 3),
+
+		testingutils.TestingCommitMessage(ks.Shares[1], 1),
+		testingutils.TestingCommitMessage(ks.Shares[2], 2),
+	}
+	return &tests.MsgProcessingSpecTest{
+		Name:          "no commit quorum",
+		Pre:           pre,
+		PostRoot:      "0a940d3ffeb4d28f3ef9de1f119aeade7ad6ec9b998548b24bd00b79739e3e0f",
+		InputMessages: msgs,
+		OutputMessages: []*qbft.SignedMessage{
+			testingutils.TestingPrepareMessage(ks.Shares[1], 1),
+			testingutils.TestingCommitMessage(ks.Shares[1], 1),
+		},
+	}
+}

--- a/qbft/spectest/tests/prepare/all_prepares_sent.go
+++ b/qbft/spectest/tests/prepare/all_prepares_sent.go
@@ -1,0 +1,34 @@
+package prepare
+
+import (
+	"github.com/bloxapp/ssv-spec/qbft"
+	"github.com/bloxapp/ssv-spec/qbft/spectest/tests"
+	"github.com/bloxapp/ssv-spec/types/testingutils"
+)
+
+// AllPreparesSent is a spec test that checks the case where all prepares are sent and quorum event is triggered more than once.
+func AllPreparesSent() tests.SpecTest {
+	ks := testingutils.Testing4SharesSet()
+	pre := testingutils.BaseInstance()
+	msgs := []*qbft.SignedMessage{
+		testingutils.TestingProposalMessage(ks.Shares[1], 1),
+
+		testingutils.TestingPrepareMessage(ks.Shares[1], 1),
+		testingutils.TestingPrepareMessage(ks.Shares[2], 2),
+		testingutils.TestingPrepareMessage(ks.Shares[3], 3),
+
+		testingutils.TestingCommitMessage(ks.Shares[1], 1),
+
+		testingutils.TestingPrepareMessage(ks.Shares[4], 4),
+	}
+	return &tests.MsgProcessingSpecTest{
+		Name:          "all prepares sent",
+		Pre:           pre,
+		PostRoot:      "a3b1009cdc2ee22b439eab30cb89aa368171d1c87589c756300286393bd78631",
+		InputMessages: msgs,
+		OutputMessages: []*qbft.SignedMessage{
+			testingutils.TestingPrepareMessage(ks.Shares[1], 1),
+			testingutils.TestingCommitMessage(ks.Shares[1], 1),
+		},
+	}
+}

--- a/qbft/spectest/tests/prepare/all_prepares_sent_late_commit.go
+++ b/qbft/spectest/tests/prepare/all_prepares_sent_late_commit.go
@@ -1,0 +1,34 @@
+package prepare
+
+import (
+	"github.com/bloxapp/ssv-spec/qbft"
+	"github.com/bloxapp/ssv-spec/qbft/spectest/tests"
+	"github.com/bloxapp/ssv-spec/types/testingutils"
+)
+
+// AllPreparesSentLateCommit is a spec test that checks the case where all prepares are sent and quorum event is triggered more than once.
+// A commit message was seen only after the last prepare
+func AllPreparesSentLateCommit() tests.SpecTest {
+	ks := testingutils.Testing4SharesSet()
+	pre := testingutils.BaseInstance()
+	msgs := []*qbft.SignedMessage{
+		testingutils.TestingProposalMessage(ks.Shares[1], 1),
+
+		testingutils.TestingPrepareMessage(ks.Shares[1], 1),
+		testingutils.TestingPrepareMessage(ks.Shares[2], 2),
+		testingutils.TestingPrepareMessage(ks.Shares[3], 3),
+
+		testingutils.TestingPrepareMessage(ks.Shares[4], 4),
+		testingutils.TestingCommitMessage(ks.Shares[1], 1),
+	}
+	return &tests.MsgProcessingSpecTest{
+		Name:          "all prepares sent",
+		Pre:           pre,
+		PostRoot:      "a3b1009cdc2ee22b439eab30cb89aa368171d1c87589c756300286393bd78631",
+		InputMessages: msgs,
+		OutputMessages: []*qbft.SignedMessage{
+			testingutils.TestingPrepareMessage(ks.Shares[1], 1),
+			testingutils.TestingCommitMessage(ks.Shares[1], 1),
+		},
+	}
+}

--- a/qbft/spectest/tests/prepare/all_prepares_sent_late_commit.go
+++ b/qbft/spectest/tests/prepare/all_prepares_sent_late_commit.go
@@ -29,6 +29,8 @@ func AllPreparesSentLateCommit() tests.SpecTest {
 		OutputMessages: []*qbft.SignedMessage{
 			testingutils.TestingPrepareMessage(ks.Shares[1], 1),
 			testingutils.TestingCommitMessage(ks.Shares[1], 1),
+			// ISSUE 214: we should have only commit broadcasted
+			testingutils.TestingCommitMessage(ks.Shares[1], 1),
 		},
 	}
 }


### PR DESCRIPTION
### Synopsis
The QBFT specification is tested by simple tests that run the consensus protocol with invalid data. We found some tests are missing, in particular there is no test for:
- a Prepare message that triggers quorum even though the commit stage is reached already; and
- a Commit message that is added to the message container but does not result in quorum.

### Impact
The tests aim to verify the correctness of the flows in the QBFT folder and in addition, the generated JSON file from the tests can be run in any implementation and hence should help developers testing their own implementation against the specification code. Missing tests can lead to wrong implementations by other developers.
