### PR TITLE
fix: (`NewValidatorRegistrationRunner`) pass `qbft.Controller` down to `BaseRunner`

### DIFF
--- a/ssv/spectest/tests/runner/duties/newduty/not_decided.go
+++ b/ssv/spectest/tests/runner/duties/newduty/not_decided.go
@@ -80,6 +80,14 @@ func NotDecided() tests.SpecTest {
 				OutputMessages:          []*types.SignedPartialSignatureMessage{},
 				ExpectedError:           expectedErr,
 			},
+			{
+				Name:                    "validator registration",
+				Runner:                  startRunner(testingutils.ValidatorRegistrationRunner(ks), &testingutils.TestingValidatorRegistrationDuty),
+				Duty:                    &testingutils.TestingValidatorRegistrationDuty,
+				PostDutyRunnerStateRoot: "f2385e5e764e83af908ce5f06801c499252e7a2f934620051b9b98e726e1edcd",
+				OutputMessages:          []*types.SignedPartialSignatureMessage{},
+				ExpectedError:           expectedErr,
+			},
 		},
 	}
 

--- a/ssv/validator_registration.go
+++ b/ssv/validator_registration.go
@@ -3,6 +3,7 @@ package ssv
 import (
 	"crypto/sha256"
 	"encoding/json"
+
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/bloxapp/ssv-spec/qbft"
@@ -23,6 +24,7 @@ type ValidatorRegistrationRunner struct {
 func NewValidatorRegistrationRunner(
 	beaconNetwork types.BeaconNetwork,
 	share *types.Share,
+	qbftController *qbft.Controller,
 	beacon BeaconNode,
 	network Network,
 	signer types.KeyManager,
@@ -32,6 +34,7 @@ func NewValidatorRegistrationRunner(
 			BeaconRoleType: types.BNRoleValidatorRegistration,
 			BeaconNetwork:  beaconNetwork,
 			Share:          share,
+			QBFTController: qbftController,
 		},
 
 		beacon:  beacon,

--- a/types/testingutils/runner.go
+++ b/types/testingutils/runner.go
@@ -133,6 +133,7 @@ var baseRunner = func(role types.BeaconRole, valCheck qbft.ProposedValueCheckF, 
 		return ssv.NewValidatorRegistrationRunner(
 			types.PraterNetwork,
 			share,
+			contr,
 			NewTestingBeaconNode(),
 			net,
 			km,


### PR DESCRIPTION
### Problem

Previously, `NewValidatorRegistrationRunner` was accepting & passing a `qbft.Controller` to it's `BaseRunner`.

Ever since this was reverted, the `BaseRunner.QBFTController` is nil and any call to `StartNewDuty` on a `ValidatorRegistrationRunner` with a running duty (non-nil `BaseRunner.State`) causes a panic on this line:

https://github.com/bloxapp/ssv-spec/blob/058889521b89589ef25d48dad0aeea0360c7a966/ssv/runner.go#L97

*(panics because`QBFTController` is `nil`)*

### Changes
- Pass a `qbft.Controller` down to `BaseRunner` in `NewValidatorRegistrationRunner`
- Added a spec test which calls `StartNewDuty` when there's already a duty running (it would panic without this PR)