### PR TITLE
No need to switch wrong sig when you tinker with signer id

### DIFF
--- a/types/testingutils/ssv_msgs.go
+++ b/types/testingutils/ssv_msgs.go
@@ -825,7 +825,7 @@ var PostConsensusWrongSigSyncCommitteeContributionMsg = func(sk *bls.SecretKey, 
 }
 
 var PostConsensusSigSyncCommitteeContributionWrongSignerMsg = func(sk *bls.SecretKey, id, beaconSigner types.OperatorID, keySet *TestKeySet) *types.SignedPartialSignatureMessage {
-	ret := postConsensusSyncCommitteeContributionMsg(sk, beaconSigner, TestingValidatorIndex, keySet, false, true, false)
+	ret := postConsensusSyncCommitteeContributionMsg(sk, beaconSigner, TestingValidatorIndex, keySet, false, false, false)
 	ret.Signer = id
 	return ret
 }


### PR DESCRIPTION
### Description

The util function should do only one thing, and use a different signer ID w.o tinkering with the sig itself