### PR TITLE
Serialize post states to JSON for QBFT tests

### DIFF
--- a/qbft/spectest/generate/main.go
+++ b/qbft/spectest/generate/main.go
@@ -23,14 +23,11 @@ func main() {
 
 	all := map[string]tests.SpecTest{}
 	for _, testF := range spectest.AllTests {
-		t := &testing.T{}
 		test := testF()
-		postStates := test.Run(t)
 		n := reflect.TypeOf(test).String() + "_" + test.TestName()
 		if all[n] != nil {
 			panic(fmt.Sprintf("duplicate test: %s\n", n))
 		}
-		writeJsonStateComparison(test.TestName(), reflect.TypeOf(test).String(), postStates)
 		all[n] = test
 	}
 
@@ -45,7 +42,16 @@ func main() {
 
 	log.Printf("found %d tests\n", len(all))
 	writeJson(byts)
+
+	for _, testF := range spectest.AllTests {
+		t := &testing.T{}
+		test := testF()
+		// generate post state comparison
+		postStates := test.Run(t)
+		writeJsonStateComparison(test.TestName(), reflect.TypeOf(test).String(), postStates)
+	}
 }
+
 func clearStateComparisonFolder() {
 	_, basedir, _, ok := runtime.Caller(0)
 	if !ok {

--- a/qbft/spectest/generate/main.go
+++ b/qbft/spectest/generate/main.go
@@ -70,7 +70,14 @@ func writeJsonStateComparison(name, testType string, postStates []types.Encoder)
 	}
 	log.Printf("writing state comparison json: %s\n", name)
 
-	byts, err := json.MarshalIndent(postStates, "", "		")
+	var post any
+	if len(postStates) == 1 {
+		post = postStates[0]
+	} else {
+		post = postStates
+	}
+
+	byts, err := json.MarshalIndent(post, "", "		")
 	if err != nil {
 		panic(err.Error())
 	}

--- a/qbft/spectest/tests/controller/futuremsg/test.go
+++ b/qbft/spectest/tests/controller/futuremsg/test.go
@@ -26,7 +26,7 @@ func (test *ControllerSyncSpecTest) TestName() string {
 	return "qbft controller sync " + test.Name
 }
 
-func (test *ControllerSyncSpecTest) Run(t *testing.T) {
+func (test *ControllerSyncSpecTest) Run(t *testing.T) []types.Encoder {
 	identifier := types.NewMsgID(testingutils.TestingSSVDomainType, testingutils.TestingValidatorPubKey[:], types.BNRoleAttester)
 	config := testingutils.TestingConfig(testingutils.Testing4SharesSet())
 	contr := testingutils.NewTestingQBFTController(
@@ -65,4 +65,6 @@ func (test *ControllerSyncSpecTest) Run(t *testing.T) {
 	} else {
 		require.NoError(t, lastErr)
 	}
+
+	return []types.Encoder{contr}
 }

--- a/qbft/spectest/tests/controller_spectest.go
+++ b/qbft/spectest/tests/controller_spectest.go
@@ -53,12 +53,12 @@ func (test *ControllerSpecTest) Run(t *testing.T) []types.Encoder {
 
 	controllers := make([]types.Encoder, len(test.RunInstanceData))
 	var lastErr error
-	for _, runData := range test.RunInstanceData {
+	for i, runData := range test.RunInstanceData {
 		if err := test.runInstanceWithData(t, contr, config, identifier, runData); err != nil {
 			lastErr = err
 		}
 		//copies contr into Controllers
-		copyAndAdd(controllers, contr)
+		controllers = copyAndAdd(controllers, contr, i)
 	}
 
 	if len(test.ExpectedError) != 0 {
@@ -70,7 +70,7 @@ func (test *ControllerSpecTest) Run(t *testing.T) []types.Encoder {
 	return controllers
 }
 
-func copyAndAdd(controllers []types.Encoder, contr *qbft.Controller) []types.Encoder {
+func copyAndAdd(controllers []types.Encoder, contr *qbft.Controller, i int) []types.Encoder {
 	byts, err := contr.Encode()
 	if err != nil {
 		return nil
@@ -79,7 +79,8 @@ func copyAndAdd(controllers []types.Encoder, contr *qbft.Controller) []types.Enc
 	if err := copied.Decode(byts); err != nil {
 		return nil
 	}
-	return append(controllers, copied)
+	controllers[i] = copied
+	return controllers
 }
 
 func (test *ControllerSpecTest) testTimer(

--- a/qbft/spectest/tests/create_message_spectest.go
+++ b/qbft/spectest/tests/create_message_spectest.go
@@ -32,7 +32,7 @@ type CreateMsgSpecTest struct {
 	ExpectedError                                    string
 }
 
-func (test *CreateMsgSpecTest) Run(t *testing.T) {
+func (test *CreateMsgSpecTest) Run(t *testing.T) []types.Encoder {
 	var msg *qbft.SignedMessage
 	var err error
 	switch test.CreateType {
@@ -50,14 +50,14 @@ func (test *CreateMsgSpecTest) Run(t *testing.T) {
 
 	if err != nil && len(test.ExpectedError) != 0 {
 		require.EqualError(t, err, test.ExpectedError)
-		return
+		return nil
 	}
 	require.NoError(t, err)
 
 	r, err2 := msg.GetRoot()
 	if len(test.ExpectedError) != 0 {
 		require.EqualError(t, err2, test.ExpectedError)
-		return
+		return nil
 	}
 	require.NoError(t, err2)
 
@@ -66,6 +66,7 @@ func (test *CreateMsgSpecTest) Run(t *testing.T) {
 		require.Fail(t, "post state not equal", diff)
 	}
 	require.EqualValues(t, test.ExpectedRoot, hex.EncodeToString(r[:]))
+	return nil
 }
 
 func (test *CreateMsgSpecTest) createCommit() (*qbft.SignedMessage, error) {

--- a/qbft/spectest/tests/messages_spectest.go
+++ b/qbft/spectest/tests/messages_spectest.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"github.com/bloxapp/ssv-spec/qbft"
+	"github.com/bloxapp/ssv-spec/types"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -15,7 +16,7 @@ type MsgSpecTest struct {
 	ExpectedError   string
 }
 
-func (test *MsgSpecTest) Run(t *testing.T) {
+func (test *MsgSpecTest) Run(t *testing.T) []types.Encoder {
 	var lastErr error
 
 	for i, msg := range test.Messages {
@@ -43,6 +44,7 @@ func (test *MsgSpecTest) Run(t *testing.T) {
 	} else {
 		require.NoError(t, lastErr)
 	}
+	return nil
 }
 
 func (test *MsgSpecTest) TestName() string {

--- a/qbft/spectest/tests/msg_processing_spectest.go
+++ b/qbft/spectest/tests/msg_processing_spectest.go
@@ -27,7 +27,7 @@ type MsgProcessingSpecTest struct {
 	ExpectedTimerState *testingutils.TimerState
 }
 
-func (test *MsgProcessingSpecTest) Run(t *testing.T) {
+func (test *MsgProcessingSpecTest) Run(t *testing.T) []types.Encoder {
 	// a simple hack to change the proposer func
 	if test.Pre.State.Height == ChangeProposerFuncInstanceHeight {
 		test.Pre.GetConfig().(*qbft.Config).ProposerF = func(state *qbft.State, round qbft.Round) types.OperatorID {
@@ -82,6 +82,8 @@ func (test *MsgProcessingSpecTest) Run(t *testing.T) {
 		diff := typescomparable.PrintDiff(test.Pre.State, test.PostState)
 		require.Fail(t, "post state not equal", diff)
 	}
+
+	return []types.Encoder{test.Pre.State}
 }
 
 func (test *MsgProcessingSpecTest) TestName() string {

--- a/qbft/spectest/tests/round_robin_spectest.go
+++ b/qbft/spectest/tests/round_robin_spectest.go
@@ -15,7 +15,7 @@ type RoundRobinSpecTest struct {
 	Proposers []types.OperatorID
 }
 
-func (test *RoundRobinSpecTest) Run(t *testing.T) {
+func (test *RoundRobinSpecTest) Run(t *testing.T) []types.Encoder {
 	require.True(t, len(test.Heights) > 0)
 	for i, h := range test.Heights {
 		r := test.Rounds[i]
@@ -27,6 +27,8 @@ func (test *RoundRobinSpecTest) Run(t *testing.T) {
 
 		require.EqualValues(t, test.Proposers[i], qbft.RoundRobinProposer(s, r))
 	}
+
+	return nil
 }
 
 func (test *RoundRobinSpecTest) TestName() string {

--- a/qbft/spectest/tests/test.go
+++ b/qbft/spectest/tests/test.go
@@ -1,10 +1,13 @@
 package tests
 
-import "testing"
+import (
+	"github.com/bloxapp/ssv-spec/types"
+	"testing"
+)
 
 type TestF func() SpecTest
 
 type SpecTest interface {
 	TestName() string
-	Run(t *testing.T)
+	Run(t *testing.T) []types.Encoder
 }

--- a/qbft/spectest/tests/timeout/test.go
+++ b/qbft/spectest/tests/timeout/test.go
@@ -27,7 +27,7 @@ func (test *SpecTest) TestName() string {
 	return "qbft timeout " + test.Name
 }
 
-func (test *SpecTest) Run(t *testing.T) {
+func (test *SpecTest) Run(t *testing.T) []types.Encoder {
 	err := test.Pre.UponRoundTimeout()
 
 	if len(test.ExpectedError) != 0 {
@@ -64,4 +64,6 @@ func (test *SpecTest) Run(t *testing.T) {
 		diff := typescomparable.PrintDiff(test.Pre.State, test.PostState)
 		require.Fail(t, "post state not equal", diff)
 	}
+
+	return []types.Encoder{test.Pre.State}
 }


### PR DESCRIPTION
### Description

Replaces #275 

Add infrastructure that enables one to generate the post states of each spec test in json format with `make generate-jsons` command. All generated jsons can be found in `spectest/generate/state_comparison` folder.
It will override the files for each run.

The generated jsons aren't added here because we want to review each test that we add jsons to.

### How was this tested.

1. Jsons were generated correctly
2. Tests all ran correctly