### PR TITLE
Remove backwards compatibility for state comparison

### DIFF
--- a/qbft/spectest/tests/controller_spectest.go
+++ b/qbft/spectest/tests/controller_spectest.go
@@ -208,11 +208,6 @@ func (test *ControllerSpecTest) overrideStateComparison(t *testing.T) {
 		r, err := sc[i].GetRoot()
 		require.NoError(t, err)
 
-		// backwards compatability test, hard coded post root must be equal to the one loaded from file
-		if len(runData.ControllerPostRoot) > 0 {
-			require.EqualValues(t, runData.ControllerPostRoot, hex.EncodeToString(r[:]))
-		}
-
 		runData.ControllerPostRoot = hex.EncodeToString(r[:])
 	}
 }

--- a/ssv/spectest/tests/msg_processing_spectest.go
+++ b/ssv/spectest/tests/msg_processing_spectest.go
@@ -187,11 +187,6 @@ func overrideStateComparison(t *testing.T, test *MsgProcessingSpecTest, name str
 	root, err := runner.GetRoot()
 	require.NoError(t, err)
 
-	// backwards compatability test, hard coded post root must be equal to the one loaded from file
-	if len(test.PostDutyRunnerStateRoot) > 0 {
-		require.EqualValues(t, test.PostDutyRunnerStateRoot, hex.EncodeToString(root[:]), "post runner state not equal")
-	}
-
 	test.PostDutyRunnerStateRoot = hex.EncodeToString(root[:])
 }
 

--- a/ssv/spectest/tests/runner/duties/newduty/test.go
+++ b/ssv/spectest/tests/runner/duties/newduty/test.go
@@ -187,10 +187,5 @@ func overrideStateComparison(t *testing.T, test *StartNewRunnerDutySpecTest, nam
 	root, err := runner.GetRoot()
 	require.NoError(t, err)
 
-	// backwards compatability test, hard coded post root must be equal to the one loaded from file
-	if len(test.PostDutyRunnerStateRoot) > 0 {
-		require.EqualValues(t, test.PostDutyRunnerStateRoot, hex.EncodeToString(root[:]), "post runner state not equal")
-	}
-
 	test.PostDutyRunnerStateRoot = hex.EncodeToString(root[:])
 }

--- a/ssv/spectest/tests/runner/duties/synccommitteeaggregator/proof_spectest.go
+++ b/ssv/spectest/tests/runner/duties/synccommitteeaggregator/proof_spectest.go
@@ -90,10 +90,5 @@ func (test *SyncCommitteeAggregatorProofSpecTest) overrideStateComparison(t *tes
 	r, err2 := postState.GetRoot()
 	require.NoError(t, err2)
 
-	// backwards compatability test, hard coded post root must be equal to the one loaded from file
-	if len(test.PostDutyRunnerStateRoot) > 0 {
-		require.EqualValues(t, test.PostDutyRunnerStateRoot, hex.EncodeToString(r[:]))
-	}
-
 	test.PostDutyRunnerStateRoot = hex.EncodeToString(r[:])
 }


### PR DESCRIPTION
Backwards compatibility makes amending the spec ridiculously slow.
So we remove it. 

When we see a test that still has a root in the json, we know it wasn't still properly vetted