### PR TITLE
Spec - Validator registration and voluntary exit now stop old duties

### DIFF
--- a/ssv/runner.go
+++ b/ssv/runner.go
@@ -88,6 +88,15 @@ func (b *BaseRunner) baseStartNewDuty(runner Runner, duty *types.Duty) error {
 	return runner.executeDuty(duty)
 }
 
+// baseStartNewBeaconDuty is a base func that all runner implementation can call to start a non-beacon duty
+func (b *BaseRunner) baseStartNewNonBeaconDuty(runner Runner, duty *types.Duty) error {
+	if err := b.ShouldProcessNonBeaconDuty(duty); err != nil {
+		return errors.Wrap(err, "can't start non-beacon duty")
+	}
+	b.baseSetupForNewDuty(duty)
+	return runner.executeDuty(duty)
+}
+
 // basePreConsensusMsgProcessing is a base func that all runner implementation can call for processing a pre-consensus msg
 func (b *BaseRunner) basePreConsensusMsgProcessing(runner Runner, signedMsg *types.SignedPartialSignatureMessage) (bool, [][32]byte, error) {
 	if err := b.ValidatePreConsensusMsg(runner, signedMsg); err != nil {
@@ -237,6 +246,14 @@ func (b *BaseRunner) ShouldProcessDuty(duty *types.Duty) error {
 	if b.QBFTController.Height >= qbft.Height(duty.Slot) && b.QBFTController.Height != 0 {
 		return errors.Errorf("duty for slot %d already passed. Current height is %d", duty.Slot,
 			b.QBFTController.Height)
+	}
+	return nil
+}
+
+func (b *BaseRunner) ShouldProcessNonBeaconDuty(duty *types.Duty) error {
+	// assume StartingDuty is not nil if state is not nil
+	if b.State != nil && b.State.StartingDuty.Slot >= duty.Slot {
+		return errors.Errorf("duty for slot %d already passed. Current duty is %d", duty.Slot, b.State.StartingDuty.Slot)
 	}
 	return nil
 }

--- a/ssv/runner.go
+++ b/ssv/runner.go
@@ -253,7 +253,8 @@ func (b *BaseRunner) ShouldProcessDuty(duty *types.Duty) error {
 func (b *BaseRunner) ShouldProcessNonBeaconDuty(duty *types.Duty) error {
 	// assume StartingDuty is not nil if state is not nil
 	if b.State != nil && b.State.StartingDuty.Slot >= duty.Slot {
-		return errors.Errorf("duty for slot %d already passed. Current duty is %d", duty.Slot, b.State.StartingDuty.Slot)
+		return errors.Errorf("duty for slot %d already passed. Current slot is %d", duty.Slot,
+			b.State.StartingDuty.Slot)
 	}
 	return nil
 }

--- a/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/duplicate_duty_finished/validator registration.json
+++ b/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/duplicate_duty_finished/validator registration.json
@@ -71,7 +71,7 @@
 								"ValidatorCommitteeIndex": 0,
 								"ValidatorSyncCommitteeIndices": null
 						},
-						"Finished": false
+						"Finished": true
 				},
 				"Share": {
 						"OperatorID": 1,

--- a/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/duplicate_duty_finished/voluntary exit.json
+++ b/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/duplicate_duty_finished/voluntary exit.json
@@ -71,7 +71,7 @@
 								"ValidatorCommitteeIndex": 0,
 								"ValidatorSyncCommitteeIndices": null
 						},
-						"Finished": false
+						"Finished": true
 				},
 				"Share": {
 						"OperatorID": 1,

--- a/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_consensus_not_started/validator registration.json
+++ b/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_consensus_not_started/validator registration.json
@@ -1,0 +1,134 @@
+{
+		"BaseRunner": {
+				"State": {
+						"PreConsensusContainer": {
+								"Signatures": {},
+								"Quorum": 3
+						},
+						"PostConsensusContainer": {
+								"Signatures": {},
+								"Quorum": 3
+						},
+						"RunningInstance": null,
+						"DecidedValue": null,
+						"StartingDuty": {
+								"Type": 5,
+								"PubKey": [
+										142,
+										128,
+										6,
+										101,
+										81,
+										168,
+										27,
+										49,
+										130,
+										88,
+										112,
+										158,
+										218,
+										247,
+										221,
+										31,
+										99,
+										205,
+										104,
+										106,
+										14,
+										77,
+										184,
+										178,
+										155,
+										187,
+										122,
+										207,
+										230,
+										86,
+										8,
+										103,
+										122,
+										245,
+										165,
+										39,
+										217,
+										68,
+										142,
+										228,
+										120,
+										53,
+										72,
+										94,
+										2,
+										181,
+										11,
+										192
+								],
+								"Slot": 12,
+								"ValidatorIndex": 1,
+								"CommitteeIndex": 0,
+								"CommitteeLength": 0,
+								"CommitteesAtSlot": 0,
+								"ValidatorCommitteeIndex": 0,
+								"ValidatorSyncCommitteeIndices": null
+						},
+						"Finished": false
+				},
+				"Share": {
+						"OperatorID": 1,
+						"ValidatorPubKey": "joAGZVGoGzGCWHCe2vfdH2PNaGoOTbiym7t6z+ZWCGd69aUn2USO5Hg1SF4CtQvA",
+						"SharePubKey": "l9lKgR1kSTYFKp0tSs1kcYl0z2eNvv0mcyTI6fjnA0pKa32HeeJ6AZU4w8Qlw+Xn",
+						"Committee": [
+								{
+										"OperatorID": 1,
+										"PubKey": "l9lKgR1kSTYFKp0tSs1kcYl0z2eNvv0mcyTI6fjnA0pKa32HeeJ6AZU4w8Qlw+Xn"
+								},
+								{
+										"OperatorID": 2,
+										"PubKey": "przr4wl9dBcbQMcSoDHOsDcds9PEAs8s5pG5Eg87q3XU1W36DzdZFUSZm/GMU1Pt"
+								},
+								{
+										"OperatorID": 3,
+										"PubKey": "gJDgt2ZqRezF1O90GKyZ8J5sskQCn+pqCn/Mvp7gi8U53g36Zr5rq8hJPdmd0amN"
+								},
+								{
+										"OperatorID": 4,
+										"PubKey": "p8CidrcKXuM5XH1tJlXtYFKKolLU0h7KX8xSI+UMxCvRaLKAq3q1MXNU3d/PPfnk"
+								}
+						],
+						"Quorum": 3,
+						"PartialQuorum": 2,
+						"DomainType": [
+								0,
+								0,
+								3,
+								1
+						],
+						"FeeRecipientAddress": [
+								83,
+								89,
+								83,
+								181,
+								166,
+								4,
+								0,
+								116,
+								148,
+								140,
+								241,
+								133,
+								234,
+								167,
+								210,
+								171,
+								189,
+								102,
+								128,
+								143
+						],
+						"Graffiti": null
+				},
+				"QBFTController": null,
+				"BeaconNetwork": "prater",
+				"BeaconRoleType": 5
+		}
+}

--- a/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_consensus_not_started/validator registration.json
+++ b/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_consensus_not_started/validator registration.json
@@ -63,7 +63,7 @@
 										11,
 										192
 								],
-								"Slot": 12,
+								"Slot": 50,
 								"ValidatorIndex": 1,
 								"CommitteeIndex": 0,
 								"CommitteeLength": 0,

--- a/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_consensus_not_started/voluntary exit.json
+++ b/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_consensus_not_started/voluntary exit.json
@@ -1,0 +1,134 @@
+{
+		"BaseRunner": {
+				"State": {
+						"PreConsensusContainer": {
+								"Signatures": {},
+								"Quorum": 3
+						},
+						"PostConsensusContainer": {
+								"Signatures": {},
+								"Quorum": 3
+						},
+						"RunningInstance": null,
+						"DecidedValue": null,
+						"StartingDuty": {
+								"Type": 6,
+								"PubKey": [
+										142,
+										128,
+										6,
+										101,
+										81,
+										168,
+										27,
+										49,
+										130,
+										88,
+										112,
+										158,
+										218,
+										247,
+										221,
+										31,
+										99,
+										205,
+										104,
+										106,
+										14,
+										77,
+										184,
+										178,
+										155,
+										187,
+										122,
+										207,
+										230,
+										86,
+										8,
+										103,
+										122,
+										245,
+										165,
+										39,
+										217,
+										68,
+										142,
+										228,
+										120,
+										53,
+										72,
+										94,
+										2,
+										181,
+										11,
+										192
+								],
+								"Slot": 12,
+								"ValidatorIndex": 1,
+								"CommitteeIndex": 0,
+								"CommitteeLength": 0,
+								"CommitteesAtSlot": 0,
+								"ValidatorCommitteeIndex": 0,
+								"ValidatorSyncCommitteeIndices": null
+						},
+						"Finished": false
+				},
+				"Share": {
+						"OperatorID": 1,
+						"ValidatorPubKey": "joAGZVGoGzGCWHCe2vfdH2PNaGoOTbiym7t6z+ZWCGd69aUn2USO5Hg1SF4CtQvA",
+						"SharePubKey": "l9lKgR1kSTYFKp0tSs1kcYl0z2eNvv0mcyTI6fjnA0pKa32HeeJ6AZU4w8Qlw+Xn",
+						"Committee": [
+								{
+										"OperatorID": 1,
+										"PubKey": "l9lKgR1kSTYFKp0tSs1kcYl0z2eNvv0mcyTI6fjnA0pKa32HeeJ6AZU4w8Qlw+Xn"
+								},
+								{
+										"OperatorID": 2,
+										"PubKey": "przr4wl9dBcbQMcSoDHOsDcds9PEAs8s5pG5Eg87q3XU1W36DzdZFUSZm/GMU1Pt"
+								},
+								{
+										"OperatorID": 3,
+										"PubKey": "gJDgt2ZqRezF1O90GKyZ8J5sskQCn+pqCn/Mvp7gi8U53g36Zr5rq8hJPdmd0amN"
+								},
+								{
+										"OperatorID": 4,
+										"PubKey": "p8CidrcKXuM5XH1tJlXtYFKKolLU0h7KX8xSI+UMxCvRaLKAq3q1MXNU3d/PPfnk"
+								}
+						],
+						"Quorum": 3,
+						"PartialQuorum": 2,
+						"DomainType": [
+								0,
+								0,
+								3,
+								1
+						],
+						"FeeRecipientAddress": [
+								83,
+								89,
+								83,
+								181,
+								166,
+								4,
+								0,
+								116,
+								148,
+								140,
+								241,
+								133,
+								234,
+								167,
+								210,
+								171,
+								189,
+								102,
+								128,
+								143
+						],
+						"Graffiti": null
+				},
+				"QBFTController": null,
+				"BeaconNetwork": "prater",
+				"BeaconRoleType": 6
+		}
+}

--- a/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_consensus_not_started/voluntary exit.json
+++ b/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_consensus_not_started/voluntary exit.json
@@ -63,7 +63,7 @@
 										11,
 										192
 								],
-								"Slot": 12,
+								"Slot": 50,
 								"ValidatorIndex": 1,
 								"CommitteeIndex": 0,
 								"CommitteeLength": 0,

--- a/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_finished/validator registration.json
+++ b/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_finished/validator registration.json
@@ -1,0 +1,134 @@
+{
+		"BaseRunner": {
+				"State": {
+						"PreConsensusContainer": {
+								"Signatures": {},
+								"Quorum": 3
+						},
+						"PostConsensusContainer": {
+								"Signatures": {},
+								"Quorum": 3
+						},
+						"RunningInstance": null,
+						"DecidedValue": null,
+						"StartingDuty": {
+								"Type": 5,
+								"PubKey": [
+										142,
+										128,
+										6,
+										101,
+										81,
+										168,
+										27,
+										49,
+										130,
+										88,
+										112,
+										158,
+										218,
+										247,
+										221,
+										31,
+										99,
+										205,
+										104,
+										106,
+										14,
+										77,
+										184,
+										178,
+										155,
+										187,
+										122,
+										207,
+										230,
+										86,
+										8,
+										103,
+										122,
+										245,
+										165,
+										39,
+										217,
+										68,
+										142,
+										228,
+										120,
+										53,
+										72,
+										94,
+										2,
+										181,
+										11,
+										192
+								],
+								"Slot": 12,
+								"ValidatorIndex": 1,
+								"CommitteeIndex": 0,
+								"CommitteeLength": 0,
+								"CommitteesAtSlot": 0,
+								"ValidatorCommitteeIndex": 0,
+								"ValidatorSyncCommitteeIndices": null
+						},
+						"Finished": false
+				},
+				"Share": {
+						"OperatorID": 1,
+						"ValidatorPubKey": "joAGZVGoGzGCWHCe2vfdH2PNaGoOTbiym7t6z+ZWCGd69aUn2USO5Hg1SF4CtQvA",
+						"SharePubKey": "l9lKgR1kSTYFKp0tSs1kcYl0z2eNvv0mcyTI6fjnA0pKa32HeeJ6AZU4w8Qlw+Xn",
+						"Committee": [
+								{
+										"OperatorID": 1,
+										"PubKey": "l9lKgR1kSTYFKp0tSs1kcYl0z2eNvv0mcyTI6fjnA0pKa32HeeJ6AZU4w8Qlw+Xn"
+								},
+								{
+										"OperatorID": 2,
+										"PubKey": "przr4wl9dBcbQMcSoDHOsDcds9PEAs8s5pG5Eg87q3XU1W36DzdZFUSZm/GMU1Pt"
+								},
+								{
+										"OperatorID": 3,
+										"PubKey": "gJDgt2ZqRezF1O90GKyZ8J5sskQCn+pqCn/Mvp7gi8U53g36Zr5rq8hJPdmd0amN"
+								},
+								{
+										"OperatorID": 4,
+										"PubKey": "p8CidrcKXuM5XH1tJlXtYFKKolLU0h7KX8xSI+UMxCvRaLKAq3q1MXNU3d/PPfnk"
+								}
+						],
+						"Quorum": 3,
+						"PartialQuorum": 2,
+						"DomainType": [
+								0,
+								0,
+								3,
+								1
+						],
+						"FeeRecipientAddress": [
+								83,
+								89,
+								83,
+								181,
+								166,
+								4,
+								0,
+								116,
+								148,
+								140,
+								241,
+								133,
+								234,
+								167,
+								210,
+								171,
+								189,
+								102,
+								128,
+								143
+						],
+						"Graffiti": null
+				},
+				"QBFTController": null,
+				"BeaconNetwork": "prater",
+				"BeaconRoleType": 5
+		}
+}

--- a/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_finished/validator registration.json
+++ b/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_finished/validator registration.json
@@ -63,7 +63,7 @@
 										11,
 										192
 								],
-								"Slot": 12,
+								"Slot": 50,
 								"ValidatorIndex": 1,
 								"CommitteeIndex": 0,
 								"CommitteeLength": 0,

--- a/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_finished/voluntary exit.json
+++ b/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_finished/voluntary exit.json
@@ -1,0 +1,134 @@
+{
+		"BaseRunner": {
+				"State": {
+						"PreConsensusContainer": {
+								"Signatures": {},
+								"Quorum": 3
+						},
+						"PostConsensusContainer": {
+								"Signatures": {},
+								"Quorum": 3
+						},
+						"RunningInstance": null,
+						"DecidedValue": null,
+						"StartingDuty": {
+								"Type": 6,
+								"PubKey": [
+										142,
+										128,
+										6,
+										101,
+										81,
+										168,
+										27,
+										49,
+										130,
+										88,
+										112,
+										158,
+										218,
+										247,
+										221,
+										31,
+										99,
+										205,
+										104,
+										106,
+										14,
+										77,
+										184,
+										178,
+										155,
+										187,
+										122,
+										207,
+										230,
+										86,
+										8,
+										103,
+										122,
+										245,
+										165,
+										39,
+										217,
+										68,
+										142,
+										228,
+										120,
+										53,
+										72,
+										94,
+										2,
+										181,
+										11,
+										192
+								],
+								"Slot": 12,
+								"ValidatorIndex": 1,
+								"CommitteeIndex": 0,
+								"CommitteeLength": 0,
+								"CommitteesAtSlot": 0,
+								"ValidatorCommitteeIndex": 0,
+								"ValidatorSyncCommitteeIndices": null
+						},
+						"Finished": false
+				},
+				"Share": {
+						"OperatorID": 1,
+						"ValidatorPubKey": "joAGZVGoGzGCWHCe2vfdH2PNaGoOTbiym7t6z+ZWCGd69aUn2USO5Hg1SF4CtQvA",
+						"SharePubKey": "l9lKgR1kSTYFKp0tSs1kcYl0z2eNvv0mcyTI6fjnA0pKa32HeeJ6AZU4w8Qlw+Xn",
+						"Committee": [
+								{
+										"OperatorID": 1,
+										"PubKey": "l9lKgR1kSTYFKp0tSs1kcYl0z2eNvv0mcyTI6fjnA0pKa32HeeJ6AZU4w8Qlw+Xn"
+								},
+								{
+										"OperatorID": 2,
+										"PubKey": "przr4wl9dBcbQMcSoDHOsDcds9PEAs8s5pG5Eg87q3XU1W36DzdZFUSZm/GMU1Pt"
+								},
+								{
+										"OperatorID": 3,
+										"PubKey": "gJDgt2ZqRezF1O90GKyZ8J5sskQCn+pqCn/Mvp7gi8U53g36Zr5rq8hJPdmd0amN"
+								},
+								{
+										"OperatorID": 4,
+										"PubKey": "p8CidrcKXuM5XH1tJlXtYFKKolLU0h7KX8xSI+UMxCvRaLKAq3q1MXNU3d/PPfnk"
+								}
+						],
+						"Quorum": 3,
+						"PartialQuorum": 2,
+						"DomainType": [
+								0,
+								0,
+								3,
+								1
+						],
+						"FeeRecipientAddress": [
+								83,
+								89,
+								83,
+								181,
+								166,
+								4,
+								0,
+								116,
+								148,
+								140,
+								241,
+								133,
+								234,
+								167,
+								210,
+								171,
+								189,
+								102,
+								128,
+								143
+						],
+						"Graffiti": null
+				},
+				"QBFTController": null,
+				"BeaconNetwork": "prater",
+				"BeaconRoleType": 6
+		}
+}

--- a/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_finished/voluntary exit.json
+++ b/ssv/spectest/generate/state_comparison/newduty_MultiStartNewRunnerDutySpecTest/new_duty_finished/voluntary exit.json
@@ -63,7 +63,7 @@
 										11,
 										192
 								],
-								"Slot": 12,
+								"Slot": 50,
 								"ValidatorIndex": 1,
 								"CommitteeIndex": 0,
 								"CommitteeLength": 0,

--- a/ssv/spectest/run_test.go
+++ b/ssv/spectest/run_test.go
@@ -39,12 +39,6 @@ func TestAll(t *testing.T) {
 	wait.Wait()
 }
 
-// TestOne will run a single test.
-func TestOne(t *testing.T) {
-	test := newduty.FirstHeight()
-	test.Run(t)
-}
-
 func TestJson(t *testing.T) {
 	t.Parallel()
 

--- a/ssv/spectest/tests/runner/duties/newduty/consensus_not_started.go
+++ b/ssv/spectest/tests/runner/duties/newduty/consensus_not_started.go
@@ -2,7 +2,6 @@ package newduty
 
 import (
 	"github.com/attestantio/go-eth2-client/spec"
-
 	"github.com/bloxapp/ssv-spec/ssv"
 	"github.com/bloxapp/ssv-spec/ssv/spectest/tests"
 	"github.com/bloxapp/ssv-spec/types"
@@ -66,6 +65,24 @@ func ConsensusNotStarted() tests.SpecTest {
 				Duty:                    &testingutils.TestingAttesterDutyNextEpoch,
 				PostDutyRunnerStateRoot: "198b4b184304c99c41b4c161bf33c1427a727f520ef946e29f4880c11646b1a3",
 				OutputMessages:          []*types.SignedPartialSignatureMessage{},
+			},
+			{
+				Name:                    "voluntary exit",
+				Runner:                  startRunner(testingutils.VoluntaryExitRunner(ks), &testingutils.TestingVoluntaryExitDuty),
+				Duty:                    &testingutils.TestingVoluntaryExitDuty,
+				PostDutyRunnerStateRoot: "6f6d918e15ebc7b84cb77e2d603019d1cbfb6d7293daddd48780da47c14e53ce",
+				OutputMessages: []*types.SignedPartialSignatureMessage{
+					testingutils.PreConsensusVoluntaryExitMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
+				},
+			},
+			{
+				Name:                    "validator registration",
+				Runner:                  startRunner(testingutils.ValidatorRegistrationRunner(ks), &testingutils.TestingValidatorRegistrationDuty),
+				Duty:                    &testingutils.TestingValidatorRegistrationDuty,
+				PostDutyRunnerStateRoot: "6f6d918e15ebc7b84cb77e2d603019d1cbfb6d7293daddd48780da47c14e53ce",
+				OutputMessages: []*types.SignedPartialSignatureMessage{
+					testingutils.PreConsensusValidatorRegistrationMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
+				},
 			},
 		},
 	}

--- a/ssv/spectest/tests/runner/duties/newduty/consensus_not_started.go
+++ b/ssv/spectest/tests/runner/duties/newduty/consensus_not_started.go
@@ -69,19 +69,19 @@ func ConsensusNotStarted() tests.SpecTest {
 			{
 				Name:                    "voluntary exit",
 				Runner:                  startRunner(testingutils.VoluntaryExitRunner(ks), &testingutils.TestingVoluntaryExitDuty),
-				Duty:                    &testingutils.TestingVoluntaryExitDuty,
+				Duty:                    &testingutils.TestingVoluntaryExitDutyNextEpoch,
 				PostDutyRunnerStateRoot: "6f6d918e15ebc7b84cb77e2d603019d1cbfb6d7293daddd48780da47c14e53ce",
 				OutputMessages: []*types.SignedPartialSignatureMessage{
-					testingutils.PreConsensusVoluntaryExitMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
+					testingutils.PreConsensusVoluntaryExitNextEpochMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
 				},
 			},
 			{
 				Name:                    "validator registration",
 				Runner:                  startRunner(testingutils.ValidatorRegistrationRunner(ks), &testingutils.TestingValidatorRegistrationDuty),
-				Duty:                    &testingutils.TestingValidatorRegistrationDuty,
+				Duty:                    &testingutils.TestingValidatorRegistrationDutyNextEpoch,
 				PostDutyRunnerStateRoot: "6f6d918e15ebc7b84cb77e2d603019d1cbfb6d7293daddd48780da47c14e53ce",
 				OutputMessages: []*types.SignedPartialSignatureMessage{
-					testingutils.PreConsensusValidatorRegistrationMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
+					testingutils.PreConsensusValidatorRegistrationNextEpochMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
 				},
 			},
 		},

--- a/ssv/spectest/tests/runner/duties/newduty/duplicate_duty_finished.go
+++ b/ssv/spectest/tests/runner/duties/newduty/duplicate_duty_finished.go
@@ -44,6 +44,11 @@ func DuplicateDutyFinished() tests.SpecTest {
 		return r
 	}
 
+	expectedTaskError := fmt.Sprintf("can't start non-beacon duty: duty for slot %d already passed. "+
+		"Current height is %d",
+		testingutils.TestingDutySlot,
+		testingutils.TestingDutySlot)
+
 	return &MultiStartNewRunnerDutySpecTest{
 		Name: "duplicate duty finished",
 		Tests: []*StartNewRunnerDutySpecTest{
@@ -99,9 +104,8 @@ func DuplicateDutyFinished() tests.SpecTest {
 					&testingutils.TestingValidatorRegistrationDuty),
 				Duty:                    &testingutils.TestingValidatorRegistrationDuty,
 				PostDutyRunnerStateRoot: "2ac409163b617c79a2a11d3919d6834d24c5c32f06113237a12afcf43e7757a0",
-				OutputMessages: []*types.SignedPartialSignatureMessage{
-					testingutils.PreConsensusValidatorRegistrationMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
-				},
+				OutputMessages:          []*types.SignedPartialSignatureMessage{},
+				ExpectedError:           expectedTaskError,
 			},
 			{
 				Name: "voluntary exit",
@@ -109,9 +113,8 @@ func DuplicateDutyFinished() tests.SpecTest {
 					&testingutils.TestingVoluntaryExitDuty),
 				Duty:                    &testingutils.TestingVoluntaryExitDuty,
 				PostDutyRunnerStateRoot: "2ac409163b617c79a2a11d3919d6834d24c5c32f06113237a12afcf43e7757a0",
-				OutputMessages: []*types.SignedPartialSignatureMessage{
-					testingutils.PreConsensusVoluntaryExitMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
-				},
+				OutputMessages:          []*types.SignedPartialSignatureMessage{},
+				ExpectedError:           expectedTaskError,
 			},
 		},
 	}

--- a/ssv/spectest/tests/runner/duties/newduty/duplicate_duty_finished.go
+++ b/ssv/spectest/tests/runner/duties/newduty/duplicate_duty_finished.go
@@ -45,7 +45,7 @@ func DuplicateDutyFinished() tests.SpecTest {
 	}
 
 	expectedTaskError := fmt.Sprintf("can't start non-beacon duty: duty for slot %d already passed. "+
-		"Current height is %d",
+		"Current slot is %d",
 		testingutils.TestingDutySlot,
 		testingutils.TestingDutySlot)
 

--- a/ssv/spectest/tests/runner/duties/newduty/duplicate_duty_not_finished.go
+++ b/ssv/spectest/tests/runner/duties/newduty/duplicate_duty_not_finished.go
@@ -42,7 +42,7 @@ func DuplicateDutyNotFinished() tests.SpecTest {
 		testingutils.TestingDutySlot)
 
 	expectedTaskError := fmt.Sprintf("can't start non-beacon duty: duty for slot %d already passed. "+
-		"Current height is %d",
+		"Current slot is %d",
 		testingutils.TestingDutySlot,
 		testingutils.TestingDutySlot)
 

--- a/ssv/spectest/tests/runner/duties/newduty/duplicate_duty_not_finished.go
+++ b/ssv/spectest/tests/runner/duties/newduty/duplicate_duty_not_finished.go
@@ -101,7 +101,6 @@ func DuplicateDutyNotFinished() tests.SpecTest {
 				OutputMessages: []*types.SignedPartialSignatureMessage{
 					testingutils.PreConsensusValidatorRegistrationMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
 				},
-				ExpectedError: expectedTaskError,
 			},
 			{
 				Name: "voluntary exit",
@@ -112,7 +111,6 @@ func DuplicateDutyNotFinished() tests.SpecTest {
 				OutputMessages: []*types.SignedPartialSignatureMessage{
 					testingutils.PreConsensusVoluntaryExitMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
 				},
-				ExpectedError: expectedTaskError,
 			},
 		},
 	}

--- a/ssv/spectest/tests/runner/duties/newduty/duplicate_duty_not_finished.go
+++ b/ssv/spectest/tests/runner/duties/newduty/duplicate_duty_not_finished.go
@@ -41,7 +41,10 @@ func DuplicateDutyNotFinished() tests.SpecTest {
 		testingutils.TestingDutySlot,
 		testingutils.TestingDutySlot)
 
-	const expectedTaskError = "already running duty"
+	expectedTaskError := fmt.Sprintf("can't start non-beacon duty: duty for slot %d already passed. "+
+		"Current height is %d",
+		testingutils.TestingDutySlot,
+		testingutils.TestingDutySlot)
 
 	return &MultiStartNewRunnerDutySpecTest{
 		Name: "duplicate duty not finished",
@@ -98,9 +101,8 @@ func DuplicateDutyNotFinished() tests.SpecTest {
 					&testingutils.TestingValidatorRegistrationDuty),
 				Duty:                    &testingutils.TestingValidatorRegistrationDuty,
 				PostDutyRunnerStateRoot: "2ac409163b617c79a2a11d3919d6834d24c5c32f06113237a12afcf43e7757a0",
-				OutputMessages: []*types.SignedPartialSignatureMessage{
-					testingutils.PreConsensusValidatorRegistrationMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
-				},
+				OutputMessages:          []*types.SignedPartialSignatureMessage{},
+				ExpectedError:           expectedTaskError,
 			},
 			{
 				Name: "voluntary exit",
@@ -108,9 +110,8 @@ func DuplicateDutyNotFinished() tests.SpecTest {
 					&testingutils.TestingVoluntaryExitDuty),
 				Duty:                    &testingutils.TestingVoluntaryExitDuty,
 				PostDutyRunnerStateRoot: "2ac409163b617c79a2a11d3919d6834d24c5c32f06113237a12afcf43e7757a0",
-				OutputMessages: []*types.SignedPartialSignatureMessage{
-					testingutils.PreConsensusVoluntaryExitMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
-				},
+				OutputMessages:          []*types.SignedPartialSignatureMessage{},
+				ExpectedError:           expectedTaskError,
 			},
 		},
 	}

--- a/ssv/spectest/tests/runner/duties/newduty/finished.go
+++ b/ssv/spectest/tests/runner/duties/newduty/finished.go
@@ -84,19 +84,19 @@ func Finished() tests.SpecTest {
 			{
 				Name:                    "voluntary exit",
 				Runner:                  finishRunner(testingutils.VoluntaryExitRunner(ks), &testingutils.TestingVoluntaryExitDuty, false),
-				Duty:                    &testingutils.TestingVoluntaryExitDuty,
+				Duty:                    &testingutils.TestingVoluntaryExitDutyNextEpoch,
 				PostDutyRunnerStateRoot: "6f6d918e15ebc7b84cb77e2d603019d1cbfb6d7293daddd48780da47c14e53ce",
 				OutputMessages: []*types.SignedPartialSignatureMessage{
-					testingutils.PreConsensusVoluntaryExitMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
+					testingutils.PreConsensusVoluntaryExitNextEpochMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
 				},
 			},
 			{
 				Name:                    "validator registration",
 				Runner:                  finishRunner(testingutils.ValidatorRegistrationRunner(ks), &testingutils.TestingValidatorRegistrationDuty, false),
-				Duty:                    &testingutils.TestingValidatorRegistrationDuty,
+				Duty:                    &testingutils.TestingValidatorRegistrationDutyNextEpoch,
 				PostDutyRunnerStateRoot: "6f6d918e15ebc7b84cb77e2d603019d1cbfb6d7293daddd48780da47c14e53ce",
 				OutputMessages: []*types.SignedPartialSignatureMessage{
-					testingutils.PreConsensusValidatorRegistrationMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
+					testingutils.PreConsensusValidatorRegistrationNextEpochMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
 				},
 			},
 		},

--- a/ssv/spectest/tests/runner/duties/newduty/finished.go
+++ b/ssv/spectest/tests/runner/duties/newduty/finished.go
@@ -16,16 +16,21 @@ func Finished() tests.SpecTest {
 
 	// TODO: check error
 	// nolint
-	finishRunner := func(r ssv.Runner, duty *types.Duty) ssv.Runner {
+	finishRunner := func(r ssv.Runner, duty *types.Duty, finishController bool) ssv.Runner {
 		r.GetBaseRunner().State = ssv.NewRunnerState(3, duty)
-		r.GetBaseRunner().State.RunningInstance = qbft.NewInstance(
-			r.GetBaseRunner().QBFTController.GetConfig(),
-			r.GetBaseRunner().Share,
-			r.GetBaseRunner().QBFTController.Identifier,
-			qbft.Height(duty.Slot))
-		r.GetBaseRunner().State.RunningInstance.State.Decided = true
-		r.GetBaseRunner().QBFTController.StoredInstances = append(r.GetBaseRunner().QBFTController.StoredInstances, r.GetBaseRunner().State.RunningInstance)
-		r.GetBaseRunner().QBFTController.Height = qbft.Height(duty.Slot)
+
+		// for duties with a consensus controller
+		if finishController {
+			r.GetBaseRunner().State.RunningInstance = qbft.NewInstance(
+				r.GetBaseRunner().QBFTController.GetConfig(),
+				r.GetBaseRunner().Share,
+				r.GetBaseRunner().QBFTController.Identifier,
+				qbft.Height(duty.Slot))
+			r.GetBaseRunner().State.RunningInstance.State.Decided = true
+			r.GetBaseRunner().QBFTController.StoredInstances = append(r.GetBaseRunner().QBFTController.StoredInstances, r.GetBaseRunner().State.RunningInstance)
+			r.GetBaseRunner().QBFTController.Height = qbft.Height(duty.Slot)
+		}
+
 		r.GetBaseRunner().State.Finished = true
 		return r
 	}
@@ -36,7 +41,7 @@ func Finished() tests.SpecTest {
 			{
 				Name: "sync committee aggregator",
 				Runner: finishRunner(testingutils.SyncCommitteeContributionRunner(ks),
-					&testingutils.TestingSyncCommitteeContributionDuty),
+					&testingutils.TestingSyncCommitteeContributionDuty, true),
 				Duty:                    &testingutils.TestingSyncCommitteeContributionNexEpochDuty,
 				PostDutyRunnerStateRoot: "fbcf8689caa2138c117d9385daa53a0c8aae76b9f12014d13a66d984f6287edf",
 				OutputMessages: []*types.SignedPartialSignatureMessage{
@@ -45,14 +50,14 @@ func Finished() tests.SpecTest {
 			},
 			{
 				Name:                    "sync committee",
-				Runner:                  finishRunner(testingutils.SyncCommitteeRunner(ks), &testingutils.TestingSyncCommitteeDuty),
+				Runner:                  finishRunner(testingutils.SyncCommitteeRunner(ks), &testingutils.TestingSyncCommitteeDuty, true),
 				Duty:                    &testingutils.TestingSyncCommitteeDutyNextEpoch,
 				PostDutyRunnerStateRoot: "b160f3edf371d390ac09b99f01ae283ffc6339649ca0352f3bd974ab2d6458b3",
 				OutputMessages:          []*types.SignedPartialSignatureMessage{},
 			},
 			{
 				Name:                    "aggregator",
-				Runner:                  finishRunner(testingutils.AggregatorRunner(ks), &testingutils.TestingAggregatorDuty),
+				Runner:                  finishRunner(testingutils.AggregatorRunner(ks), &testingutils.TestingAggregatorDuty, true),
 				Duty:                    &testingutils.TestingAggregatorDutyNextEpoch,
 				PostDutyRunnerStateRoot: "e5ffdb2d4b64133979b73370c757b94e2f82952238d7c2bcdc91fbe1782ec80a",
 				OutputMessages: []*types.SignedPartialSignatureMessage{
@@ -62,7 +67,7 @@ func Finished() tests.SpecTest {
 			{
 				Name: "proposer",
 				Runner: finishRunner(testingutils.ProposerRunner(ks),
-					testingutils.TestingProposerDutyV(spec.DataVersionBellatrix)),
+					testingutils.TestingProposerDutyV(spec.DataVersionBellatrix), true),
 				Duty:                    testingutils.TestingProposerDutyNextEpochV(spec.DataVersionBellatrix),
 				PostDutyRunnerStateRoot: "78a040ec69b6932809c8b582999277d3e9766d564eacde7eeb029f0749460f39",
 				OutputMessages: []*types.SignedPartialSignatureMessage{
@@ -71,10 +76,28 @@ func Finished() tests.SpecTest {
 			},
 			{
 				Name:                    "attester",
-				Runner:                  finishRunner(testingutils.AttesterRunner(ks), &testingutils.TestingAttesterDuty),
+				Runner:                  finishRunner(testingutils.AttesterRunner(ks), &testingutils.TestingAttesterDuty, true),
 				Duty:                    &testingutils.TestingAttesterDutyNextEpoch,
 				PostDutyRunnerStateRoot: "cbfb9b6302ff1e7a1bf356f57a8e88dd4c4f7ddef6345c62dac125af1d1db4ce",
 				OutputMessages:          []*types.SignedPartialSignatureMessage{},
+			},
+			{
+				Name:                    "voluntary exit",
+				Runner:                  finishRunner(testingutils.VoluntaryExitRunner(ks), &testingutils.TestingVoluntaryExitDuty, false),
+				Duty:                    &testingutils.TestingVoluntaryExitDuty,
+				PostDutyRunnerStateRoot: "6f6d918e15ebc7b84cb77e2d603019d1cbfb6d7293daddd48780da47c14e53ce",
+				OutputMessages: []*types.SignedPartialSignatureMessage{
+					testingutils.PreConsensusVoluntaryExitMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
+				},
+			},
+			{
+				Name:                    "validator registration",
+				Runner:                  finishRunner(testingutils.ValidatorRegistrationRunner(ks), &testingutils.TestingValidatorRegistrationDuty, false),
+				Duty:                    &testingutils.TestingValidatorRegistrationDuty,
+				PostDutyRunnerStateRoot: "6f6d918e15ebc7b84cb77e2d603019d1cbfb6d7293daddd48780da47c14e53ce",
+				OutputMessages: []*types.SignedPartialSignatureMessage{
+					testingutils.PreConsensusValidatorRegistrationMsg(ks.Shares[1], 1), // broadcasts when starting a new duty
+				},
 			},
 		},
 	}

--- a/ssv/validator_registration.go
+++ b/ssv/validator_registration.go
@@ -43,8 +43,7 @@ func NewValidatorRegistrationRunner(
 
 func (r *ValidatorRegistrationRunner) StartNewDuty(duty *types.Duty) error {
 	// Note: Validator registration doesn't require any consensus, it can always start a new duty even if previous one didn't finish
-	r.BaseRunner.baseSetupForNewDuty(duty)
-	return r.executeDuty(duty)
+	return r.BaseRunner.baseStartNewNonBeaconDuty(r, duty)
 }
 
 // HasRunningDuty returns true if a duty is already running (StartNewDuty called and returned nil)

--- a/ssv/validator_registration.go
+++ b/ssv/validator_registration.go
@@ -42,7 +42,7 @@ func NewValidatorRegistrationRunner(
 }
 
 func (r *ValidatorRegistrationRunner) StartNewDuty(duty *types.Duty) error {
-	// Note: Validator registration doesn't require any consensus, it can always start a new duty even if previous one didn't finish
+	// Note: Validator registration doesn't require any consensus, it can start a new duty even if previous one didn't finish
 	return r.BaseRunner.baseStartNewNonBeaconDuty(r, duty)
 }
 

--- a/ssv/validator_registration.go
+++ b/ssv/validator_registration.go
@@ -42,11 +42,7 @@ func NewValidatorRegistrationRunner(
 }
 
 func (r *ValidatorRegistrationRunner) StartNewDuty(duty *types.Duty) error {
-	// Note: Unlike the other runners, this doesn't call BaseRunner.baseStartNewDuty because
-	// that requires a QBFTController which ValidatorRegistrationRunner doesn't have.
-	if r.HasRunningDuty() {
-		return errors.New("already running duty")
-	}
+	// Note: Validator registration doesn't require any consensus, it can always start a new duty even if previous one didn't finish
 	r.BaseRunner.baseSetupForNewDuty(duty)
 	return r.executeDuty(duty)
 }

--- a/ssv/voluntary_exit.go
+++ b/ssv/voluntary_exit.go
@@ -45,8 +45,7 @@ func NewVoluntaryExitRunner(
 
 func (r *VoluntaryExitRunner) StartNewDuty(duty *types.Duty) error {
 	// Note: Voluntary exit doesn't require any consensus, it can always start a new duty even if previous one didn't finish
-	r.BaseRunner.baseSetupForNewDuty(duty)
-	return r.executeDuty(duty)
+	return r.BaseRunner.baseStartNewNonBeaconDuty(r, duty)
 }
 
 // HasRunningDuty returns true if a duty is already running (StartNewDuty called and returned nil)

--- a/ssv/voluntary_exit.go
+++ b/ssv/voluntary_exit.go
@@ -44,11 +44,7 @@ func NewVoluntaryExitRunner(
 }
 
 func (r *VoluntaryExitRunner) StartNewDuty(duty *types.Duty) error {
-	// Note: Unlike the other runners, this doesn't call BaseRunner.baseStartNewDuty because
-	// that requires a QBFTController which VoluntaryExitRunner doesn't have.
-	if r.HasRunningDuty() {
-		return errors.New("already running duty")
-	}
+	// Note: Voluntary exit doesn't require any consensus, it can always start a new duty even if previous one didn't finish
 	r.BaseRunner.baseSetupForNewDuty(duty)
 	return r.executeDuty(duty)
 }
@@ -58,7 +54,7 @@ func (r *VoluntaryExitRunner) HasRunningDuty() bool {
 	return r.BaseRunner.hasRunningDuty()
 }
 
-// Check for quorum of partial signatures over VoluntaryExit and,
+// ProcessPreConsensus Check for quorum of partial signatures over VoluntaryExit and,
 // if has quorum, constructs SignedVoluntaryExit and submits to BeaconNode
 func (r *VoluntaryExitRunner) ProcessPreConsensus(signedMsg *types.SignedPartialSignatureMessage) error {
 	quorum, roots, err := r.BaseRunner.basePreConsensusMsgProcessing(r, signedMsg)

--- a/ssv/voluntary_exit.go
+++ b/ssv/voluntary_exit.go
@@ -44,7 +44,7 @@ func NewVoluntaryExitRunner(
 }
 
 func (r *VoluntaryExitRunner) StartNewDuty(duty *types.Duty) error {
-	// Note: Voluntary exit doesn't require any consensus, it can always start a new duty even if previous one didn't finish
+	// Note: Voluntary exit doesn't require any consensus, it can start a new duty even if previous one didn't finish
 	return r.BaseRunner.baseStartNewNonBeaconDuty(r, duty)
 }
 

--- a/types/testingutils/beacon_node.go
+++ b/types/testingutils/beacon_node.go
@@ -225,7 +225,6 @@ const (
 	TestingDutySlot       = 12
 	TestingDutySlot2      = 50
 	TestingDutyEpoch      = 0
-	TestingDutyEpoch2     = 1
 	TestingValidatorIndex = 1
 
 	UnknownDutyType = 100

--- a/types/testingutils/beacon_node.go
+++ b/types/testingutils/beacon_node.go
@@ -331,6 +331,17 @@ var TestingValidatorRegistrationWrong = &v1.ValidatorRegistration{
 	Pubkey:       TestingValidatorPubKey,
 }
 
+// TestingValidatorRegistrationBySlot receives a slot and calculates the correct timestamp
+func TestingValidatorRegistrationBySlot(slot phase0.Slot) *v1.ValidatorRegistration {
+	epoch := types.PraterNetwork.EstimatedEpochAtSlot(slot)
+	return &v1.ValidatorRegistration{
+		FeeRecipient: TestingFeeRecipient,
+		GasLimit:     types.DefaultGasLimit,
+		Timestamp:    types.PraterNetwork.EpochStartTime(epoch),
+		Pubkey:       TestingValidatorPubKey,
+	}
+}
+
 var TestingVoluntaryExit = &phase0.VoluntaryExit{
 	Epoch:          0,
 	ValidatorIndex: TestingValidatorIndex,

--- a/types/testingutils/beacon_node.go
+++ b/types/testingutils/beacon_node.go
@@ -225,6 +225,7 @@ const (
 	TestingDutySlot       = 12
 	TestingDutySlot2      = 50
 	TestingDutyEpoch      = 0
+	TestingDutyEpoch2     = 1
 	TestingValidatorIndex = 1
 
 	UnknownDutyType = 100
@@ -504,10 +505,24 @@ var TestingValidatorRegistrationDuty = types.Duty{
 	ValidatorIndex: TestingValidatorIndex,
 }
 
+var TestingValidatorRegistrationDutyNextEpoch = types.Duty{
+	Type:           types.BNRoleValidatorRegistration,
+	PubKey:         TestingValidatorPubKey,
+	Slot:           TestingDutySlot2,
+	ValidatorIndex: TestingValidatorIndex,
+}
+
 var TestingVoluntaryExitDuty = types.Duty{
 	Type:           types.BNRoleVoluntaryExit,
 	PubKey:         TestingValidatorPubKey,
 	Slot:           TestingDutySlot,
+	ValidatorIndex: TestingValidatorIndex,
+}
+
+var TestingVoluntaryExitDutyNextEpoch = types.Duty{
+	Type:           types.BNRoleVoluntaryExit,
+	PubKey:         TestingValidatorPubKey,
+	Slot:           TestingDutySlot2,
 	ValidatorIndex: TestingValidatorIndex,
 }
 

--- a/types/testingutils/beacon_node.go
+++ b/types/testingutils/beacon_node.go
@@ -357,6 +357,15 @@ var TestingSignedVoluntaryExit = func(ks *TestKeySet) *phase0.SignedVoluntaryExi
 	}
 }
 
+// TestingVoluntaryExitBySlot receives a slot and calculates the correct epoch
+func TestingVoluntaryExitBySlot(slot phase0.Slot) *phase0.VoluntaryExit {
+	epoch := types.PraterNetwork.EstimatedEpochAtSlot(slot)
+	return &phase0.VoluntaryExit{
+		Epoch:          epoch,
+		ValidatorIndex: TestingValidatorIndex,
+	}
+}
+
 // TestingProposerDutyFirstSlot
 var TestingProposerDutyFirstSlot = types.Duty{
 	Type:           types.BNRoleProposer,

--- a/types/testingutils/ssv_msgs.go
+++ b/types/testingutils/ssv_msgs.go
@@ -429,23 +429,23 @@ var selectionProofMsg = func(
 }
 
 var PreConsensusValidatorRegistrationMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
-	return validatorRegistrationMsg(msgSK, msgSK, msgID, msgID, 1, false, TestingDutyEpoch, false)
+	return validatorRegistrationMsg(msgSK, msgSK, msgID, msgID, 1, false, TestingDutySlot, false)
 }
 
 var PreConsensusValidatorRegistrationTooFewRootsMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
-	return validatorRegistrationMsg(msgSK, msgSK, msgID, msgID, 0, false, TestingDutyEpoch, false)
+	return validatorRegistrationMsg(msgSK, msgSK, msgID, msgID, 0, false, TestingDutySlot, false)
 }
 
 var PreConsensusValidatorRegistrationTooManyRootsMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
-	return validatorRegistrationMsg(msgSK, msgSK, msgID, msgID, 2, false, TestingDutyEpoch, false)
+	return validatorRegistrationMsg(msgSK, msgSK, msgID, msgID, 2, false, TestingDutySlot, false)
 }
 
 var PreConsensusValidatorRegistrationWrongRootMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
-	return validatorRegistrationMsg(msgSK, msgSK, msgID, msgID, 1, true, TestingDutyEpoch, false)
+	return validatorRegistrationMsg(msgSK, msgSK, msgID, msgID, 1, true, TestingDutySlot, false)
 }
 
 var PreConsensusValidatorRegistrationNextEpochMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
-	return validatorRegistrationMsg(msgSK, msgSK, msgID, msgID, 1, false, TestingDutyEpoch2, false)
+	return validatorRegistrationMsg(msgSK, msgSK, msgID, msgID, 1, false, TestingDutySlot2, false)
 }
 
 var validatorRegistrationMsg = func(
@@ -453,12 +453,12 @@ var validatorRegistrationMsg = func(
 	id, beaconID types.OperatorID,
 	msgCnt int,
 	wrongRoot bool,
-	epoch phase0.Epoch,
+	slot phase0.Slot,
 	wrongBeaconSig bool,
 ) *types.SignedPartialSignatureMessage {
 	signer := NewTestingKeyManager()
 	beacon := NewTestingBeaconNode()
-	d, _ := beacon.DomainData(epoch, types.DomainApplicationBuilder)
+	d, _ := beacon.DomainData(TestingDutyEpoch, types.DomainApplicationBuilder)
 
 	signed, root, _ := signer.SignBeaconObject(TestingValidatorRegistration, d, beaconSK.GetPublicKey().Serialize(), types.DomainApplicationBuilder)
 	if wrongRoot {
@@ -470,7 +470,7 @@ var validatorRegistrationMsg = func(
 
 	msgs := types.PartialSignatureMessages{
 		Type:     types.ValidatorRegistrationPartialSig,
-		Slot:     TestingDutySlot,
+		Slot:     slot,
 		Messages: []*types.PartialSignatureMessage{},
 	}
 

--- a/types/testingutils/ssv_msgs.go
+++ b/types/testingutils/ssv_msgs.go
@@ -460,7 +460,9 @@ var validatorRegistrationMsg = func(
 	beacon := NewTestingBeaconNode()
 	d, _ := beacon.DomainData(TestingDutyEpoch, types.DomainApplicationBuilder)
 
-	signed, root, _ := signer.SignBeaconObject(TestingValidatorRegistration, d, beaconSK.GetPublicKey().Serialize(), types.DomainApplicationBuilder)
+	signed, root, _ := signer.SignBeaconObject(TestingValidatorRegistrationBySlot(slot), d,
+		beaconSK.GetPublicKey().Serialize(),
+		types.DomainApplicationBuilder)
 	if wrongRoot {
 		signed, root, _ = signer.SignBeaconObject(TestingValidatorRegistrationWrong, d, beaconSK.GetPublicKey().Serialize(), types.DomainApplicationBuilder)
 	}

--- a/types/testingutils/ssv_msgs.go
+++ b/types/testingutils/ssv_msgs.go
@@ -444,6 +444,10 @@ var PreConsensusValidatorRegistrationWrongRootMsg = func(msgSK *bls.SecretKey, m
 	return validatorRegistrationMsg(msgSK, msgSK, msgID, msgID, 1, true, TestingDutyEpoch, false)
 }
 
+var PreConsensusValidatorRegistrationNextEpochMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
+	return validatorRegistrationMsg(msgSK, msgSK, msgID, msgID, 1, false, TestingDutyEpoch2, false)
+}
+
 var validatorRegistrationMsg = func(
 	sk, beaconSK *bls.SecretKey,
 	id, beaconID types.OperatorID,
@@ -498,6 +502,10 @@ var validatorRegistrationMsg = func(
 
 var PreConsensusVoluntaryExitMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
 	return VoluntaryExitMsg(msgSK, msgSK, msgID, msgID, 1, false, TestingDutyEpoch, false)
+}
+
+var PreConsensusVoluntaryExitNextEpochMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
+	return VoluntaryExitMsg(msgSK, msgSK, msgID, msgID, 1, false, TestingDutyEpoch2, false)
 }
 
 var PreConsensusVoluntaryExitTooFewRootsMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {

--- a/types/testingutils/ssv_msgs.go
+++ b/types/testingutils/ssv_msgs.go
@@ -503,23 +503,23 @@ var validatorRegistrationMsg = func(
 }
 
 var PreConsensusVoluntaryExitMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
-	return VoluntaryExitMsg(msgSK, msgSK, msgID, msgID, 1, false, TestingDutyEpoch, false)
+	return VoluntaryExitMsg(msgSK, msgSK, msgID, msgID, 1, false, TestingDutySlot, false)
 }
 
 var PreConsensusVoluntaryExitNextEpochMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
-	return VoluntaryExitMsg(msgSK, msgSK, msgID, msgID, 1, false, TestingDutyEpoch2, false)
+	return VoluntaryExitMsg(msgSK, msgSK, msgID, msgID, 1, false, TestingDutySlot2, false)
 }
 
 var PreConsensusVoluntaryExitTooFewRootsMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
-	return VoluntaryExitMsg(msgSK, msgSK, msgID, msgID, 0, false, TestingDutyEpoch, false)
+	return VoluntaryExitMsg(msgSK, msgSK, msgID, msgID, 0, false, TestingDutySlot, false)
 }
 
 var PreConsensusVoluntaryExitTooManyRootsMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
-	return VoluntaryExitMsg(msgSK, msgSK, msgID, msgID, 2, false, TestingDutyEpoch, false)
+	return VoluntaryExitMsg(msgSK, msgSK, msgID, msgID, 2, false, TestingDutySlot, false)
 }
 
 var PreConsensusVoluntaryExitWrongRootMsg = func(msgSK *bls.SecretKey, msgID types.OperatorID) *types.SignedPartialSignatureMessage {
-	return VoluntaryExitMsg(msgSK, msgSK, msgID, msgID, 1, true, TestingDutyEpoch, false)
+	return VoluntaryExitMsg(msgSK, msgSK, msgID, msgID, 1, true, TestingDutySlot, false)
 }
 
 var VoluntaryExitMsg = func(
@@ -527,14 +527,16 @@ var VoluntaryExitMsg = func(
 	id, beaconID types.OperatorID,
 	msgCnt int,
 	wrongRoot bool,
-	epoch phase0.Epoch,
+	slot phase0.Slot,
 	wrongBeaconSig bool,
 ) *types.SignedPartialSignatureMessage {
 	signer := NewTestingKeyManager()
 	beacon := NewTestingBeaconNode()
-	d, _ := beacon.DomainData(epoch, types.DomainVoluntaryExit)
+	d, _ := beacon.DomainData(TestingDutyEpoch, types.DomainVoluntaryExit)
 
-	signed, root, _ := signer.SignBeaconObject(TestingVoluntaryExit, d, beaconSK.GetPublicKey().Serialize(), types.DomainVoluntaryExit)
+	signed, root, _ := signer.SignBeaconObject(TestingVoluntaryExitBySlot(slot), d,
+		beaconSK.GetPublicKey().Serialize(),
+		types.DomainVoluntaryExit)
 	if wrongRoot {
 		signed, root, _ = signer.SignBeaconObject(TestingVoluntaryExitWrong, d, beaconSK.GetPublicKey().Serialize(), types.DomainVoluntaryExit)
 	}
@@ -544,7 +546,7 @@ var VoluntaryExitMsg = func(
 
 	msgs := types.PartialSignatureMessages{
 		Type:     types.VoluntaryExitPartialSig,
-		Slot:     TestingDutySlot,
+		Slot:     slot,
 		Messages: []*types.PartialSignatureMessage{},
 	}
 


### PR DESCRIPTION
# Description

Stalling ValidatorRegistration/ValidatorExit duties prevented the execution of new duties. Now when a duty that fits a higher slot comes in it stops the old one.

# Affected tests

Added missing cases to:
`consensus_not_started`, `duplicate_duty_finished`, `duplicate_duty_not_finished`, and `finished`.