### PR TITLE
Drop duplicated value check call

### DIFF
--- a/qbft/controller.go
+++ b/qbft/controller.go
@@ -37,9 +37,6 @@ func NewController(
 
 // StartNewInstance will start a new QBFT instance, if can't will return error
 func (c *Controller) StartNewInstance(height Height, value []byte) error {
-	if err := c.GetConfig().GetValueCheckF()(value); err != nil {
-		return errors.Wrap(err, "value invalid")
-	}
 
 	// can't use <= because of height == 0 case
 	if height < c.Height {


### PR DESCRIPTION
Drop duplicated value check call as pointed by https://github.com/bloxapp/ssv-spec/issues/325.

Closes https://github.com/bloxapp/ssv-spec/issues/325.