### PR TITLE
Fix round number in qbft tests

### DIFF
--- a/qbft/spectest/generate/state_comparison/tests_CreateMsgSpecTest/qbft create message create round change no justification quorum.json
+++ b/qbft/spectest/generate/state_comparison/tests_CreateMsgSpecTest/qbft create message create round change no justification quorum.json
@@ -35,7 +35,7 @@
 				0
 		],
 		"StateValue": "AQIDBAUGBwgJAQIDBAUGBwgJAQIDBAUGBwgJ",
-		"Round": 0,
+		"Round": 1,
 		"RoundChangeJustifications": null,
 		"PrepareJustifications": [
 				{

--- a/qbft/spectest/generate/state_comparison/tests_CreateMsgSpecTest/qbft create message create round change previously prepared.json
+++ b/qbft/spectest/generate/state_comparison/tests_CreateMsgSpecTest/qbft create message create round change previously prepared.json
@@ -35,7 +35,7 @@
 				0
 		],
 		"StateValue": null,
-		"Round": 0,
+		"Round": 1,
 		"RoundChangeJustifications": null,
 		"PrepareJustifications": [
 				{

--- a/qbft/spectest/generate/state_comparison/tests_CreateMsgSpecTest/qbft create message create round change.json
+++ b/qbft/spectest/generate/state_comparison/tests_CreateMsgSpecTest/qbft create message create round change.json
@@ -35,7 +35,7 @@
 				0
 		],
 		"StateValue": null,
-		"Round": 0,
+		"Round": 1,
 		"RoundChangeJustifications": null,
 		"PrepareJustifications": null,
 		"CreateType": "CreateRoundChange",

--- a/qbft/spectest/generate/tests/tests.CreateMsgSpecTest_qbft_create_message_create_round_change.json
+++ b/qbft/spectest/generate/tests/tests.CreateMsgSpecTest_qbft_create_message_create_round_change.json
@@ -35,7 +35,7 @@
     0
   ],
   "StateValue": null,
-  "Round": 0,
+  "Round": 1,
   "RoundChangeJustifications": null,
   "PrepareJustifications": null,
   "CreateType": "CreateRoundChange",

--- a/qbft/spectest/generate/tests/tests.CreateMsgSpecTest_qbft_create_message_create_round_change_no_justification_quorum.json
+++ b/qbft/spectest/generate/tests/tests.CreateMsgSpecTest_qbft_create_message_create_round_change_no_justification_quorum.json
@@ -35,7 +35,7 @@
     0
   ],
   "StateValue": "AQIDBAUGBwgJAQIDBAUGBwgJAQIDBAUGBwgJ",
-  "Round": 0,
+  "Round": 1,
   "RoundChangeJustifications": null,
   "PrepareJustifications": [
     {

--- a/qbft/spectest/generate/tests/tests.CreateMsgSpecTest_qbft_create_message_create_round_change_previously_prepared.json
+++ b/qbft/spectest/generate/tests/tests.CreateMsgSpecTest_qbft_create_message_create_round_change_previously_prepared.json
@@ -35,7 +35,7 @@
     0
   ],
   "StateValue": null,
-  "Round": 0,
+  "Round": 1,
   "RoundChangeJustifications": null,
   "PrepareJustifications": [
     {

--- a/qbft/spectest/tests/create_message_spectest.go
+++ b/qbft/spectest/tests/create_message_spectest.go
@@ -57,12 +57,16 @@ func (test *CreateMsgSpecTest) Run(t *testing.T) {
 	}
 	require.NoError(t, err)
 
-	r, err2 := msg.GetRoot()
+	if test.Round == qbft.NoRound {
+		require.Fail(t, "qbft round is invalid")
+	}
+
+	r, err := msg.GetRoot()
 	if len(test.ExpectedError) != 0 {
-		require.EqualError(t, err2, test.ExpectedError)
+		require.EqualError(t, err, test.ExpectedError)
 		return
 	}
-	require.NoError(t, err2)
+	require.NoError(t, err)
 
 	if test.ExpectedRoot != hex.EncodeToString(r[:]) {
 		fmt.Printf("expected: %v\n", test.ExpectedRoot)
@@ -149,7 +153,7 @@ func (test *CreateMsgSpecTest) createRoundChange() (*types.SignedSSVMessage, err
 		}
 	}
 
-	return qbft.CreateRoundChange(state, signer, 1, test.Value[:])
+	return qbft.CreateRoundChange(state, signer, qbft.FirstRound, test.Value[:])
 }
 
 func (test *CreateMsgSpecTest) TestName() string {

--- a/qbft/spectest/tests/messages/create_round_change.go
+++ b/qbft/spectest/tests/messages/create_round_change.go
@@ -1,12 +1,16 @@
 package messages
 
-import "github.com/ssvlabs/ssv-spec/qbft/spectest/tests"
+import (
+	"github.com/ssvlabs/ssv-spec/qbft"
+	"github.com/ssvlabs/ssv-spec/qbft/spectest/tests"
+)
 
 // CreateRoundChange tests creating a round change msg, not previously prepared
 func CreateRoundChange() tests.SpecTest {
 	return &tests.CreateMsgSpecTest{
 		CreateType:   tests.CreateRoundChange,
 		Name:         "create round change",
+		Round:        qbft.FirstRound,
 		Value:        [32]byte{1, 2, 3, 4},
 		ExpectedRoot: "a6ffc48674f1522fb90aa7bde2aa76cac54480cf366cdd4afcd7f8b4d548809a",
 	}

--- a/qbft/spectest/tests/messages/create_round_change_no_justification_quorum.go
+++ b/qbft/spectest/tests/messages/create_round_change_no_justification_quorum.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ssvlabs/ssv-spec/types/testingutils/comparable"
 )
 
-// CreateRoundChangeNoJustificationQuorum tests creating a round change msg that was previouly prepared
+// CreateRoundChangeNoJustificationQuorum tests creating a round change msg that was previously prepared
 // but failed to extract a justification quorum (shouldn't happen).
 // The result should be an unjustified round change.
 func CreateRoundChangeNoJustificationQuorum() tests.SpecTest {
@@ -17,6 +17,7 @@ func CreateRoundChangeNoJustificationQuorum() tests.SpecTest {
 	return &tests.CreateMsgSpecTest{
 		CreateType:    tests.CreateRoundChange,
 		Name:          "create round change no justification quorum",
+		Round:         qbft.FirstRound,
 		StateValue:    testingutils.TestingQBFTFullData,
 		ExpectedState: sc.ExpectedState,
 		PrepareJustifications: []*types.SignedSSVMessage{
@@ -31,7 +32,7 @@ func CreateRoundChangeNoJustificationQuorumSC() *comparable.StateComparison {
 	expectedMsg := qbft.Message{
 		MsgType:                  qbft.RoundChangeMsgType,
 		Height:                   0,
-		Round:                    1,
+		Round:                    qbft.FirstRound,
 		Identifier:               testingutils.TestingIdentifier,
 		Root:                     testingutils.TestingQBFTRootData,
 		DataRound:                1,

--- a/qbft/spectest/tests/messages/create_round_change_prev_prepared.go
+++ b/qbft/spectest/tests/messages/create_round_change_prev_prepared.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"github.com/ssvlabs/ssv-spec/qbft"
 	"github.com/ssvlabs/ssv-spec/qbft/spectest/tests"
 	"github.com/ssvlabs/ssv-spec/types"
 	"github.com/ssvlabs/ssv-spec/types/testingutils"
@@ -12,6 +13,7 @@ func CreateRoundChangePreviouslyPrepared() tests.SpecTest {
 	return &tests.CreateMsgSpecTest{
 		CreateType: tests.CreateRoundChange,
 		Name:       "create round change previously prepared",
+		Round:      qbft.FirstRound,
 		Value:      [32]byte{1, 2, 3, 4},
 		PrepareJustifications: []*types.SignedSSVMessage{
 			testingutils.TestingPrepareMessage(ks.OperatorKeys[1], types.OperatorID(1)),


### PR DESCRIPTION
closes #551 

In QBFT create message spec tests, some tests do not specify round number, as a result the round is set to 0 (qbft.noRound), which is not quite valid. This PR assigns round number 1 to these tests.