### PR TITLE
fix(round change) - advance round only after successful broadcast

### DIFF
--- a/qbft/round_change.go
+++ b/qbft/round_change.go
@@ -85,9 +85,6 @@ func (i *Instance) uponRoundChange(
 }
 
 func (i *Instance) uponChangeRoundPartialQuorum(newRound Round, instanceStartValue []byte) error {
-	i.State.Round = newRound
-	i.State.ProposalAcceptedForCurrentRound = nil
-	i.config.GetTimer().TimeoutForRound(i.State.Round)
 	roundChange, err := CreateRoundChange(i.State, i.signer, newRound, instanceStartValue)
 	if err != nil {
 		return errors.Wrap(err, "failed to create round change message")
@@ -95,6 +92,7 @@ func (i *Instance) uponChangeRoundPartialQuorum(newRound Round, instanceStartVal
 	if err := i.Broadcast(roundChange); err != nil {
 		return errors.Wrap(err, "failed to broadcast round change message")
 	}
+	i.advanceRound(newRound)
 	return nil
 }
 

--- a/qbft/timeout.go
+++ b/qbft/timeout.go
@@ -18,17 +18,18 @@ var (
 	CutoffRound = 12 // stop processing attestations after 8*2+120*3 = 6.2 min (~ 1 epoch)
 )
 
+func (i *Instance) advanceRound(newRound Round) {
+	i.State.Round = newRound
+	i.State.ProposalAcceptedForCurrentRound = nil
+	i.config.GetTimer().TimeoutForRound(newRound)
+}
+
 func (i *Instance) UponRoundTimeout() error {
 	if !i.CanProcessMessages() {
 		return types.NewError(types.TimeoutInstanceErrorCode, "instance stopped processing timeouts")
 	}
 
 	newRound := i.State.Round + 1
-	defer func() {
-		i.State.Round = newRound
-		i.State.ProposalAcceptedForCurrentRound = nil
-		i.config.GetTimer().TimeoutForRound(i.State.Round)
-	}()
 
 	roundChange, err := CreateRoundChange(i.State, i.signer, newRound, i.StartValue)
 	if err != nil {
@@ -39,5 +40,6 @@ func (i *Instance) UponRoundTimeout() error {
 		return errors.Wrap(err, "failed to broadcast round change message")
 	}
 
+	i.advanceRound(newRound)
 	return nil
 }

--- a/qbft/timeout_round_advance_test.go
+++ b/qbft/timeout_round_advance_test.go
@@ -1,0 +1,90 @@
+package qbft_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ssvlabs/ssv-spec/qbft"
+	"github.com/ssvlabs/ssv-spec/types"
+	"github.com/ssvlabs/ssv-spec/types/testingutils"
+)
+
+type failingNetwork struct {
+	err      error
+	attempts int
+}
+
+func (n *failingNetwork) Broadcast(_ types.MessageID, _ *types.SignedSSVMessage) error {
+	n.attempts++
+	return n.err
+}
+
+func newTestInstanceWithFailingNetwork(t *testing.T) (*qbft.Instance, *testingutils.TestQBFTTimer, *failingNetwork, *testingutils.TestKeySet) {
+	t.Helper()
+
+	ks := testingutils.Testing4SharesSet()
+	config := testingutils.TestingConfig(ks)
+	timer, ok := config.Timer.(*testingutils.TestQBFTTimer)
+	require.True(t, ok)
+
+	network := &failingNetwork{err: errors.New("network down")}
+	config.Network = network
+
+	instance := qbft.NewInstance(
+		config,
+		testingutils.TestingCommitteeMember(ks),
+		testingutils.TestingIdentifier,
+		qbft.FirstHeight,
+		testingutils.TestingOperatorSigner(ks),
+	)
+	instance.StartValue = testingutils.TestingQBFTFullData
+
+	return instance, timer, network, ks
+}
+
+func TestUponRoundTimeoutDoesNotAdvanceRoundWhenBroadcastFails(t *testing.T) {
+	instance, timer, network, ks := newTestInstanceWithFailingNetwork(t)
+	originalProposal := testingutils.ToProcessingMessage(
+		testingutils.TestingProposalMessage(ks.OperatorKeys[1], types.OperatorID(1)),
+	)
+	instance.State.ProposalAcceptedForCurrentRound = originalProposal
+
+	err := instance.UponRoundTimeout()
+	require.ErrorContains(t, err, "failed to broadcast round change message")
+
+	require.Equal(t, qbft.FirstRound, instance.State.Round)
+	require.Same(t, originalProposal, instance.State.ProposalAcceptedForCurrentRound)
+	require.Equal(t, 0, timer.State.Timeouts)
+	require.Equal(t, qbft.NoRound, timer.State.Round)
+	require.Equal(t, 1, network.attempts)
+}
+
+func TestProcessMsgDoesNotAdvanceRoundOnPartialQuorumWhenBroadcastFails(t *testing.T) {
+	instance, timer, network, ks := newTestInstanceWithFailingNetwork(t)
+	originalProposal := testingutils.ToProcessingMessage(
+		testingutils.TestingProposalMessage(ks.OperatorKeys[1], types.OperatorID(1)),
+	)
+	instance.State.ProposalAcceptedForCurrentRound = originalProposal
+
+	msg1, err := qbft.NewProcessingMessage(
+		testingutils.TestingRoundChangeMessageWithRound(ks.OperatorKeys[2], types.OperatorID(2), qbft.FirstRound+1),
+	)
+	require.NoError(t, err)
+	_, _, _, err = instance.ProcessMsg(msg1)
+	require.NoError(t, err)
+
+	msg2, err := qbft.NewProcessingMessage(
+		testingutils.TestingRoundChangeMessageWithRound(ks.OperatorKeys[3], types.OperatorID(3), qbft.FirstRound+1),
+	)
+	require.NoError(t, err)
+	_, _, _, err = instance.ProcessMsg(msg2)
+	require.ErrorContains(t, err, "failed to broadcast round change message")
+
+	require.Equal(t, qbft.FirstRound, instance.State.Round)
+	require.Same(t, originalProposal, instance.State.ProposalAcceptedForCurrentRound)
+	require.Equal(t, 0, timer.State.Timeouts)
+	require.Equal(t, qbft.NoRound, timer.State.Round)
+	require.Equal(t, 1, network.attempts)
+}


### PR DESCRIPTION
## Summary

  Fix QBFT round advancement so an instance only moves to the next round after a round change message is successfully broadcast.

  ## Problem

  The timeout path advanced `State.Round` and reset the timer via `defer`, which meant the local instance could move
  to the next round even if:
  - `CreateRoundChange()` failed
  - `Broadcast()` failed

  The same behavior existed in the partial-quorum round change path.

  This could leave a node ahead of the committee locally without ever sending its round change message, which is a
  liveness / desynchronization risk.

  ## Changes

  - added a shared `advanceRound()` helper for local round state updates
  - updated `UponRoundTimeout()` to advance round only after successful round change broadcast
  - updated `uponChangeRoundPartialQuorum()` to do the same
  - preserved current behavior for successful round changes

  ## Why

  This keeps local round state, timer progression, and network-visible round changes consistent:
  - if round change creation or broadcast fails, the instance stays in the current round
  - the node does not reject current-round messages prematurely
  - timer state is not advanced unless the round transition was actually emitted

  ## Tests

  Added targeted QBFT tests covering broadcast failure cases:
  - timeout path does not advance round on failed round change broadcast
  - partial-quorum path does not advance round on failed round change broadcast

  ## Verification

  - `go test ./qbft ./types/testingutils`
  
  Closes https://github.com/ssvlabs/ssv-node-board/issues/844