### PR TITLE
fix(error handling) - Do not ignore msg validation errors, refactor

### DIFF
--- a/qbft/messages.go
+++ b/qbft/messages.go
@@ -153,7 +153,7 @@ func processingMessagesFromSignedMessages(signedMessages []*types.SignedSSVMessa
 	for _, signedMessage := range signedMessages {
 		msg, err := NewProcessingMessage(signedMessage)
 		if err != nil {
-			return nil, errors.Wrap(err, "decode justification message")
+			return nil, errors.Wrap(err, "decode signed SSV message")
 		}
 		ret = append(ret, msg)
 	}

--- a/qbft/messages.go
+++ b/qbft/messages.go
@@ -118,6 +118,24 @@ func (msg *Message) GetPrepareJustifications() ([]*types.SignedSSVMessage, error
 	return unmarshalJustifications(msg.PrepareJustification)
 }
 
+func (msg *Message) RoundChangeJustificationProcessingMessages() ([]*ProcessingMessage, error) {
+	signedMessages, err := msg.GetRoundChangeJustifications()
+	if err != nil {
+		return nil, err
+	}
+
+	return processingMessagesFromSignedMessages(signedMessages)
+}
+
+func (msg *Message) PrepareJustificationProcessingMessages() ([]*ProcessingMessage, error) {
+	signedMessages, err := msg.GetPrepareJustifications()
+	if err != nil {
+		return nil, err
+	}
+
+	return processingMessagesFromSignedMessages(signedMessages)
+}
+
 func unmarshalJustifications(data [][]byte) ([]*types.SignedSSVMessage, error) {
 	ret := make([]*types.SignedSSVMessage, len(data))
 	for i, d := range data {
@@ -126,6 +144,18 @@ func unmarshalJustifications(data [][]byte) ([]*types.SignedSSVMessage, error) {
 			return nil, types.WrapError(types.UnmarshalSSZErrorCode, fmt.Errorf("unmarshal justification: %w", err))
 		}
 		ret[i] = sMsg
+	}
+	return ret, nil
+}
+
+func processingMessagesFromSignedMessages(signedMessages []*types.SignedSSVMessage) ([]*ProcessingMessage, error) {
+	ret := make([]*ProcessingMessage, 0, len(signedMessages))
+	for _, signedMessage := range signedMessages {
+		msg, err := NewProcessingMessage(signedMessage)
+		if err != nil {
+			return nil, errors.Wrap(err, "decode justification message")
+		}
+		ret = append(ret, msg)
 	}
 	return ret, nil
 }

--- a/qbft/messages_test.go
+++ b/qbft/messages_test.go
@@ -1,0 +1,46 @@
+package qbft_test
+
+import (
+	"testing"
+
+	"github.com/ssvlabs/ssv-spec/qbft"
+	"github.com/ssvlabs/ssv-spec/types"
+	"github.com/ssvlabs/ssv-spec/types/testingutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundChangeJustificationProcessingMessagesReturnsDecodeError(t *testing.T) {
+	keySet := testingutils.Testing4SharesSet()
+	justification := testingutils.TestingProposalMessage(keySet.OperatorKeys[1], types.OperatorID(1))
+	justification.SSVMessage.Data = []byte{1, 2, 3}
+
+	justifications, err := qbft.MarshalJustifications([]*types.SignedSSVMessage{justification})
+	require.NoError(t, err)
+
+	msg := &qbft.Message{
+		RoundChangeJustification: justifications,
+	}
+
+	processingMessages, err := msg.RoundChangeJustificationProcessingMessages()
+	require.Nil(t, processingMessages)
+	require.Error(t, err)
+}
+
+func TestPrepareJustificationProcessingMessages(t *testing.T) {
+	keySet := testingutils.Testing4SharesSet()
+	justification := testingutils.TestingPrepareMessage(keySet.OperatorKeys[1], types.OperatorID(1))
+
+	justifications, err := qbft.MarshalJustifications([]*types.SignedSSVMessage{justification})
+	require.NoError(t, err)
+
+	msg := &qbft.Message{
+		PrepareJustification: justifications,
+	}
+
+	processingMessages, err := msg.PrepareJustificationProcessingMessages()
+	require.NoError(t, err)
+	require.Len(t, processingMessages, 1)
+	require.Equal(t, qbft.PrepareMsgType, processingMessages[0].QBFTMessage.MsgType)
+	require.Equal(t, qbft.FirstHeight, processingMessages[0].QBFTMessage.Height)
+	require.Equal(t, qbft.FirstRound, processingMessages[0].QBFTMessage.Round)
+}

--- a/qbft/messages_test.go
+++ b/qbft/messages_test.go
@@ -23,7 +23,7 @@ func TestRoundChangeJustificationProcessingMessagesReturnsDecodeError(t *testing
 
 	processingMessages, err := msg.RoundChangeJustificationProcessingMessages()
 	require.Nil(t, processingMessages)
-	require.ErrorContains(t, err, "decode justification message")
+	require.ErrorContains(t, err, "decode signed SSV message")
 }
 
 func TestRoundChangeJustificationProcessingMessages(t *testing.T) {
@@ -78,6 +78,6 @@ func TestPrepareJustificationProcessingMessagesReturnsDecodeError(t *testing.T) 
 
 	processingMessages, err := msg.PrepareJustificationProcessingMessages()
 	require.Nil(t, processingMessages)
-	require.ErrorContains(t, err, "decode justification message")
+	require.ErrorContains(t, err, "decode signed SSV message")
 }
 

--- a/qbft/messages_test.go
+++ b/qbft/messages_test.go
@@ -80,4 +80,3 @@ func TestPrepareJustificationProcessingMessagesReturnsDecodeError(t *testing.T) 
 	require.Nil(t, processingMessages)
 	require.ErrorContains(t, err, "decode signed SSV message")
 }
-

--- a/qbft/messages_test.go
+++ b/qbft/messages_test.go
@@ -23,7 +23,26 @@ func TestRoundChangeJustificationProcessingMessagesReturnsDecodeError(t *testing
 
 	processingMessages, err := msg.RoundChangeJustificationProcessingMessages()
 	require.Nil(t, processingMessages)
-	require.Error(t, err)
+	require.ErrorContains(t, err, "decode justification message")
+}
+
+func TestRoundChangeJustificationProcessingMessages(t *testing.T) {
+	keySet := testingutils.Testing4SharesSet()
+	justification := testingutils.TestingRoundChangeMessageWithRound(keySet.OperatorKeys[1], types.OperatorID(1), 2)
+
+	justifications, err := qbft.MarshalJustifications([]*types.SignedSSVMessage{justification})
+	require.NoError(t, err)
+
+	msg := &qbft.Message{
+		RoundChangeJustification: justifications,
+	}
+
+	processingMessages, err := msg.RoundChangeJustificationProcessingMessages()
+	require.NoError(t, err)
+	require.Len(t, processingMessages, 1)
+	require.Equal(t, qbft.RoundChangeMsgType, processingMessages[0].QBFTMessage.MsgType)
+	require.Equal(t, qbft.FirstHeight, processingMessages[0].QBFTMessage.Height)
+	require.Equal(t, qbft.Round(2), processingMessages[0].QBFTMessage.Round)
 }
 
 func TestPrepareJustificationProcessingMessages(t *testing.T) {
@@ -44,3 +63,21 @@ func TestPrepareJustificationProcessingMessages(t *testing.T) {
 	require.Equal(t, qbft.FirstHeight, processingMessages[0].QBFTMessage.Height)
 	require.Equal(t, qbft.FirstRound, processingMessages[0].QBFTMessage.Round)
 }
+
+func TestPrepareJustificationProcessingMessagesReturnsDecodeError(t *testing.T) {
+	keySet := testingutils.Testing4SharesSet()
+	justification := testingutils.TestingPrepareMessage(keySet.OperatorKeys[1], types.OperatorID(1))
+	justification.SSVMessage.Data = []byte{1, 2, 3}
+
+	justifications, err := qbft.MarshalJustifications([]*types.SignedSSVMessage{justification})
+	require.NoError(t, err)
+
+	msg := &qbft.Message{
+		PrepareJustification: justifications,
+	}
+
+	processingMessages, err := msg.PrepareJustificationProcessingMessages()
+	require.Nil(t, processingMessages)
+	require.ErrorContains(t, err, "decode justification message")
+}
+

--- a/qbft/proposal.go
+++ b/qbft/proposal.go
@@ -85,24 +85,14 @@ func isValidProposal(
 	}
 
 	// get justifications
-	roundChangeJustificationSignedMessages, _ := msg.QBFTMessage.GetRoundChangeJustifications() // no need to check error, checked on signedProposal.Validate()
-	prepareJustificationSignedMessages, _ := msg.QBFTMessage.GetPrepareJustifications()         // no need to check error, checked on signedProposal.Validate()
-
-	roundChangeJustification := make([]*ProcessingMessage, 0)
-	for _, rcSignedMessage := range roundChangeJustificationSignedMessages {
-		rc, err := NewProcessingMessage(rcSignedMessage)
-		if err != nil {
-			return errors.Wrap(err, "could not create ProcessingMessage from round change justification")
-		}
-		roundChangeJustification = append(roundChangeJustification, rc)
+	roundChangeJustification, err := msg.QBFTMessage.RoundChangeJustificationProcessingMessages()
+	if err != nil {
+		return errors.Wrap(err, "could not decode round change justification")
 	}
-	prepareJustification := make([]*ProcessingMessage, 0)
-	for _, prepareSignedMessage := range prepareJustificationSignedMessages {
-		msg, err := NewProcessingMessage(prepareSignedMessage)
-		if err != nil {
-			return errors.Wrap(err, "could not create ProcessingMessage from prepare justification")
-		}
-		prepareJustification = append(prepareJustification, msg)
+
+	prepareJustification, err := msg.QBFTMessage.PrepareJustificationProcessingMessages()
+	if err != nil {
+		return errors.Wrap(err, "could not decode prepare justification")
 	}
 
 	if err := isProposalJustification(

--- a/qbft/round_change.go
+++ b/qbft/round_change.go
@@ -44,15 +44,9 @@ func (i *Instance) uponRoundChange(
 
 	if justifiedRoundChangeMsg != nil {
 
-		roundChangeJustificationSignedMessages, _ := justifiedRoundChangeMsg.QBFTMessage.GetRoundChangeJustifications() // no need to check error, check on isValidRoundChange
-
-		roundChangeJustification := make([]*ProcessingMessage, 0)
-		for _, rcSignedMessage := range roundChangeJustificationSignedMessages {
-			rc, err := NewProcessingMessage(rcSignedMessage)
-			if err != nil {
-				return errors.Wrap(err, "could not create ProcessingMessage from round change justification")
-			}
-			roundChangeJustification = append(roundChangeJustification, rc)
+		roundChangeJustification, err := justifiedRoundChangeMsg.QBFTMessage.RoundChangeJustificationProcessingMessages()
+		if err != nil {
+			return errors.Wrap(err, "could not decode round change justification")
 		}
 
 		proposal, err := CreateProposal(
@@ -144,15 +138,9 @@ func hasReceivedProposalJustificationForLeadingRound(
 			valueToPropose = containerRoundChangeMessage.SignedMessage.FullData
 		}
 
-		roundChangeSignedMessagesJustification, _ := containerRoundChangeMessage.QBFTMessage.GetRoundChangeJustifications() // no need to check error, checked on isValidRoundChange
-
-		roundChangeJustification := make([]*ProcessingMessage, 0)
-		for _, signedMessage := range roundChangeSignedMessagesJustification {
-			msg, err := NewProcessingMessage(signedMessage)
-			if err != nil {
-				return nil, nil, errors.Wrap(err, "could not create ProcessingMessage from round change justification")
-			}
-			roundChangeJustification = append(roundChangeJustification, msg)
+		roundChangeJustification, err := containerRoundChangeMessage.QBFTMessage.RoundChangeJustificationProcessingMessages()
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "could not decode round change justification")
 		}
 
 		if isProposalJustificationForLeadingRound(
@@ -272,15 +260,9 @@ func validRoundChangeForDataIgnoreSignature(
 		}
 
 		// validate prepare message justifications
-		prepareSignedMsgs, _ := msg.QBFTMessage.GetRoundChangeJustifications() // no need to check error, checked on msg.QBFTMessage.Validate()
-
-		prepareMsgs := make([]*ProcessingMessage, 0)
-		for _, signedMessage := range prepareSignedMsgs {
-			msg, err := NewProcessingMessage(signedMessage)
-			if err != nil {
-				return errors.Wrap(err, "could not create ProcessingMessage from prepare message in round change justification")
-			}
-			prepareMsgs = append(prepareMsgs, msg)
+		prepareMsgs, err := msg.QBFTMessage.RoundChangeJustificationProcessingMessages()
+		if err != nil {
+			return errors.Wrap(err, "could not decode prepare message in round change justification")
 		}
 
 		for _, pm := range prepareMsgs {


### PR DESCRIPTION
## Summary

  Refactor QBFT justification decoding to stop suppressing extraction errors and centralize conversion of
  justification messages into `ProcessingMessage`s.

  ## Problem

  Several QBFT call sites were extracting justifications like this:

  - call `GetRoundChangeJustifications()` / `GetPrepareJustifications()`
  - ignore the returned error
  - loop over `[]*types.SignedSSVMessage`
  - convert each item into `*ProcessingMessage`

  The current code path relied on earlier `Validate()` calls to catch malformed justification bytes, so this was not
  an active validation bypass today. But the error handling was non-local and brittle, and the conversion logic was
  duplicated across proposal and round-change flows.

  ## Changes

  - added shared helpers on `qbft.Message`:
    - `RoundChangeJustificationProcessingMessages()`
    - `PrepareJustificationProcessingMessages()`
  - added an internal helper to convert `[]*types.SignedSSVMessage` into `[]*ProcessingMessage`
  - updated proposal and round-change call sites to use the shared helpers
  - removed ignored justification extraction errors at those call sites
  - kept the successful-path behavior unchanged:
    - same justification source fields
    - same item order
    - same `NewProcessingMessage(...)` conversion path

  ## Why

  This makes the invariant local at the point of use:
  - malformed justifications now return explicit errors instead of relying on prior validation elsewhere
  - the repeated decode/wrap loops are centralized
  - future refactors are less likely to accidentally reintroduce silent error suppression

  ## Tests

  Added focused QBFT unit tests covering:
  - malformed round-change justification payloads return a decode error
  - valid prepare justifications are converted into `ProcessingMessage`s successfully
  
  Closes https://github.com/ssvlabs/ssv-node-board/issues/845
  Closes https://github.com/ssvlabs/ssv-node-board/issues/843