### PR TITLE
Standardize sentinel pattern (F-ssv-spec-027)

### DIFF
--- a/types/messages.go
+++ b/types/messages.go
@@ -49,13 +49,13 @@ func (msg MessageID) GetDutyExecutorID() []byte {
 
 func (msg MessageID) GetRoleType() RunnerRole {
 	roleByts := msg[roleTypeStartPos : roleTypeStartPos+roleTypeSize]
-	return RunnerRole(binary.LittleEndian.Uint32(roleByts))
+	return RunnerRoleFromWireUint32(binary.LittleEndian.Uint32(roleByts))
 }
 
 func NewValidatorMsgID(domain DomainType, validatorPK ValidatorPK, role RunnerRole) MessageID {
 	mid := MessageID{}
 	copy(mid[domainStartPos:domainStartPos+domainSize], domain[:])
-	binary.LittleEndian.PutUint32(mid[roleTypeStartPos:roleTypeStartPos+roleTypeSize], uint32(role))
+	binary.LittleEndian.PutUint32(mid[roleTypeStartPos:roleTypeStartPos+roleTypeSize], role.WireUint32())
 	copy(mid[dutyExecutorIDStartPos:dutyExecutorIDStartPos+dutyExecutorIDSize], validatorPK[:])
 	return mid
 }
@@ -63,7 +63,7 @@ func NewValidatorMsgID(domain DomainType, validatorPK ValidatorPK, role RunnerRo
 func NewCommitteeMsgID(domain DomainType, committeeID CommitteeID, role RunnerRole) MessageID {
 	mid := MessageID{}
 	copy(mid[domainStartPos:domainStartPos+domainSize], domain[:])
-	binary.LittleEndian.PutUint32(mid[roleTypeStartPos:roleTypeStartPos+roleTypeSize], uint32(role))
+	binary.LittleEndian.PutUint32(mid[roleTypeStartPos:roleTypeStartPos+roleTypeSize], role.WireUint32())
 	// CommitteeID is 32 bytes, right-aligned in the 48-byte executor ID slot.
 	copy(mid[dutyExecutorIDStartPos+dutyExecutorIDSize-len(committeeID):dutyExecutorIDStartPos+dutyExecutorIDSize], committeeID[:])
 	return mid

--- a/types/runner_role.go
+++ b/types/runner_role.go
@@ -1,5 +1,7 @@
 package types
 
+import "math"
+
 // https://github.com/ssvlabs/ssv-spec/issues/423 - this can be taken down to one byte on the wire
 type RunnerRole int32
 
@@ -11,6 +13,30 @@ const (
 	RoleAggregatorCommittee   = RunnerRole(6) // Combines aggregator and sync committee contribution duties
 	RoleUnknown               = RunnerRole(-1)
 )
+
+const runnerRoleUnknownWireUint32 = uint32(math.MaxUint32)
+
+// WireUint32 returns the canonical on-wire representation for RunnerRole.
+//
+// Note: RunnerRole is encoded as a 4-byte little-endian uint32 in MessageID.
+// RoleUnknown uses the all-ones sentinel (MaxUint32), consistent with other enums
+// (e.g. BeaconRole uses MaxUint64).
+func (r RunnerRole) WireUint32() uint32 {
+	if r == RoleUnknown || r < 0 {
+		return runnerRoleUnknownWireUint32
+	}
+	return uint32(r)
+}
+
+// RunnerRoleFromWireUint32 converts a 4-byte uint32 MessageID role field into RunnerRole.
+// Values outside the int32 range are treated as unknown to avoid surprising negative roles.
+func RunnerRoleFromWireUint32(v uint32) RunnerRole {
+	// Any value outside the int32 range (including the RoleUnknown sentinel) is treated as unknown.
+	if v > uint32(math.MaxInt32) {
+		return RoleUnknown
+	}
+	return RunnerRole(int32(v))
+}
 
 // String returns the name of the runner role
 func (r RunnerRole) String() string {

--- a/types/runner_role_test.go
+++ b/types/runner_role_test.go
@@ -1,0 +1,49 @@
+package types
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunnerRoleWireMapping(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, uint32(math.MaxUint32), RoleUnknown.WireUint32())
+	require.Equal(t, RoleUnknown, RunnerRoleFromWireUint32(uint32(math.MaxUint32)))
+
+	// Arbitrary negative role (not RoleUnknown) should also map to sentinel.
+	require.Equal(t, uint32(math.MaxUint32), RunnerRole(-42).WireUint32())
+
+	for _, role := range []RunnerRole{
+		RoleCommittee,
+		RoleProposer,
+		RoleValidatorRegistration,
+		RoleVoluntaryExit,
+		RoleAggregatorCommittee,
+	} {
+		require.Equal(t, role, RunnerRoleFromWireUint32(role.WireUint32()))
+	}
+
+	// Values outside the int32 range must not produce surprising negative roles.
+	require.Equal(t, RoleUnknown, RunnerRoleFromWireUint32(0x80000000))
+}
+
+func TestMessageIDRoleTypeDecoding(t *testing.T) {
+	t.Parallel()
+
+	dutyExecutorID := make([]byte, dutyExecutorIDSize)
+	for i := range dutyExecutorID {
+		dutyExecutorID[i] = byte(i)
+	}
+
+	var validatorPK ValidatorPK
+	copy(validatorPK[:], dutyExecutorID)
+	msgID := NewValidatorMsgID(GenesisMainnet, validatorPK, RoleUnknown)
+	require.Equal(t, RoleUnknown, msgID.GetRoleType())
+
+	roleWire := binary.LittleEndian.Uint32(msgID[roleTypeStartPos : roleTypeStartPos+roleTypeSize])
+	require.Equal(t, uint32(math.MaxUint32), roleWire)
+}


### PR DESCRIPTION
Fix for:

Inconsistent Enum Sentinel Values
ssv-spec · Inconsistency · Assigned: dev4 · Effort: —
`BNRoleUnknown = math.MaxUint64` (BeaconRole) vs `RoleUnknown = -1` (RunnerRole as int32). The RunnerRole sentinel `-1` can't be properly represented as uint32 (line 50-52 in messages.go converts to uint32), potentially matching corrupted data.

Impact: Type confusion between sentinel values. Corrupted message data could match `RoleUnknown` unintentionally.

Recommendation: Standardize sentinel pattern across all enums.