### PR TITLE
Use invalid committee duty errors for malformed duties - F-ssv-spec-053

### DIFF
--- a/ssv/committee.go
+++ b/ssv/committee.go
@@ -71,7 +71,7 @@ func (c *Committee) StartDuty(duty types.Duty) error {
 	switch d := duty.(type) {
 	case *types.CommitteeDuty:
 		if d == nil {
-			return types.NewError(types.UnknownDutyRoleDataErrorCode, "nil committee duty")
+			return types.NewError(types.InvalidCommitteeDutyErrorCode, "nil committee duty")
 		}
 		slot = phase0.Slot(d.Slot)
 		runnerMap = &c.CommitteeRunners

--- a/ssv/committee_test.go
+++ b/ssv/committee_test.go
@@ -173,4 +173,6 @@ func TestCommitteeStartDutyRejectsNilCommitteeDuty(t *testing.T) {
 	var duty *types.CommitteeDuty
 	err := committee.StartDuty(duty)
 	require.EqualError(t, err, "nil committee duty")
+	require.ErrorIs(t, err, &types.Error{})
+	require.Equal(t, types.InvalidCommitteeDutyErrorCode, err.(*types.Error).Code)
 }

--- a/types/beacon_types.go
+++ b/types/beacon_types.go
@@ -184,17 +184,17 @@ func (cd *CommitteeDuty) RunnerRole() RunnerRole {
 // - Each duty must pass ValidatorDuty.Validate()
 func (cd *CommitteeDuty) Validate() error {
 	if cd == nil {
-		return NewError(UnknownDutyRoleDataErrorCode, "nil committee duty")
+		return NewError(InvalidCommitteeDutyErrorCode, "nil committee duty")
 	}
 	if len(cd.ValidatorDuties) == 0 {
 		return NewError(NoBeaconDutiesErrorCode, "no beacon duties")
 	}
 	for _, vd := range cd.ValidatorDuties {
 		if vd == nil {
-			return NewError(UnknownDutyRoleDataErrorCode, "nil validator duty")
+			return NewError(InvalidCommitteeDutyErrorCode, "nil validator duty")
 		}
 		if vd.Slot != cd.Slot {
-			return NewError(UnknownDutyRoleDataErrorCode, "mismatched slot in validator duty")
+			return NewError(InvalidCommitteeDutyErrorCode, "mismatched slot in validator duty")
 		}
 		if vd.Type != BNRoleAttester && vd.Type != BNRoleSyncCommittee {
 			return NewError(WrongBeaconRoleTypeErrorCode, "invalid beacon role in validator duty")

--- a/types/error.go
+++ b/types/error.go
@@ -99,6 +99,7 @@ const (
 	InvalidCommitteeMemberErrorCode
 	InvalidValidatorDutyErrorCode
 	BeaconVoteNilCheckpointErrorCode
+	InvalidCommitteeDutyErrorCode
 )
 
 type Error struct {

--- a/types/validation_test.go
+++ b/types/validation_test.go
@@ -88,3 +88,46 @@ func TestBeaconVoteValidate(t *testing.T) {
 		require.Equal(t, AttestationSourceNotLessThanTargetErrorCode, err.(*Error).Code)
 	})
 }
+
+func TestCommitteeDutyValidate(t *testing.T) {
+	t.Run("nil committee duty", func(t *testing.T) {
+		var duty *CommitteeDuty
+		err := duty.Validate()
+		require.Error(t, err)
+		require.ErrorIs(t, err, &Error{})
+		require.Equal(t, InvalidCommitteeDutyErrorCode, err.(*Error).Code)
+	})
+
+	t.Run("nil validator duty", func(t *testing.T) {
+		err := (&CommitteeDuty{
+			Slot: 1,
+			ValidatorDuties: []*ValidatorDuty{
+				nil,
+			},
+		}).Validate()
+		require.Error(t, err)
+		require.ErrorIs(t, err, &Error{})
+		require.Equal(t, InvalidCommitteeDutyErrorCode, err.(*Error).Code)
+	})
+
+	t.Run("mismatched validator duty slot", func(t *testing.T) {
+		var pubKey phase0.BLSPubKey
+		pubKey[0] = 1
+
+		err := (&CommitteeDuty{
+			Slot: 1,
+			ValidatorDuties: []*ValidatorDuty{
+				{
+					Type:                    BNRoleAttester,
+					PubKey:                  pubKey,
+					Slot:                    2,
+					CommitteeLength:         1,
+					ValidatorCommitteeIndex: 0,
+				},
+			},
+		}).Validate()
+		require.Error(t, err)
+		require.ErrorIs(t, err, &Error{})
+		require.Equal(t, InvalidCommitteeDutyErrorCode, err.(*Error).Code)
+	})
+}


### PR DESCRIPTION
## Ticket

F-ssv-spec-053

The ticket reported that `Committee.StartDuty` returned `UnknownDutyRoleDataErrorCode` for a nil `*CommitteeDuty`, while nil aggregator committee duties used `InvalidAggregatorCommitteeDutyErrorCode`. This conflated malformed committee duties with unknown consensus duty roles.

## Changes

- Added `InvalidCommitteeDutyErrorCode` without shifting existing error code values.
- Used the new code for malformed committee duty validation paths.
- Added focused tests covering the committee duty error code.

## Validation

- `go test ./types`
- `go test ./ssv`
- `make fmt`
- `make lint`

Fixes - Fixes ssvlabs/ssv-node-board#1031
