### PR TITLE
ci: use supported golangci-lint installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 GOPATH?=$(shell go env GOPATH)
 TEST_PKG?=./...
+GOLANGCI_LINT_VERSION?=v2.11.4
 
 .PHONY: lint-prepare
 lint-prepare:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s latest
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- $(GOLANGCI_LINT_VERSION)
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 GOPATH?=$(shell go env GOPATH)
 TEST_PKG?=./...
-GOLANGCI_LINT_VERSION?=v2.11.4
 
 .PHONY: lint-prepare
 lint-prepare:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- $(GOLANGCI_LINT_VERSION)
+	curl -sfL https://golangci-lint.run/install.sh| sh -s latest
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
Updates the golangci-lint installer URL from the retired `master` branch script to the supported installer URL recommended by upstream. This keeps the existing `latest` behavior while avoiding the checksum matching issue triggered by newer release assets.

The v2.12.2 tarball checksum itself appears valid; the failure is in the old installer path used by this repo. Upstream closed the issue as a duplicate and recommended this installer URL here: https://github.com/golangci/golangci-lint/issues/6572#issuecomment-4400895705

No sync workflow behavior or generated spec-test behavior is changed.

Verification: installed the current latest linter locally through the supported installer URL and ran the lint target successfully.
