### PR TITLE
Review fixes for #610: spec-tests sync hardening, fork policy, docs

### DIFF
--- a/.github/actions/generate-spec-tests/action.yaml
+++ b/.github/actions/generate-spec-tests/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v6.3.0
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version: 1.22.x
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
+  # "/" covers .github/workflows only. The composite action lives outside that
+  # directory, so it needs its own entry or its pins never get bumped.
   - package-ecosystem: github-actions
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/generate-spec-tests"
     schedule:
       interval: weekly

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -93,7 +93,7 @@ Runs on every push to `main`.
 
 ### Fork PRs
 
-Fork PRs get no mirror branch or mirror PR while open, because `pull_request` from a fork receives no secrets. Their fixtures are still generated and tested by `test.yaml`, which needs no secrets, so correctness is verified. After merge, `sync-spec-tests-merge.yaml` pushes their fixtures straight to the `spec-tests` base branch. Contributing from a branch in `ssvlabs/ssv-spec` is the recommended path: it gets the mirror PR preview while the PR is open.
+Fork PRs get no mirror branch or mirror PR while open, because `pull_request` from a fork receives no secrets. Their fixtures are still generated and tested by `test.yaml`, which needs no secrets, so correctness is verified. Their fixtures reach spec-tests with the next merge from an in-repo branch, because each sync replaces the entire generated tree. Contributing from a branch in `ssvlabs/ssv-spec` is the recommended path: it gets the mirror PR preview while the PR is open.
 
 ---
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -93,7 +93,9 @@ Runs on every push to `main`.
 
 ### Fork PRs
 
-Fork PRs get no mirror branch or mirror PR while open, because `pull_request` from a fork receives no secrets. Their fixtures are still generated and tested by `test.yaml`, which needs no secrets, so correctness is verified. Their fixtures reach spec-tests with the next merge from an in-repo branch, because each sync replaces the entire generated tree. Contributing from a branch in `ssvlabs/ssv-spec` is the recommended path: it gets the mirror PR preview while the PR is open.
+Fork PRs get no mirror branch or mirror PR while open, because `pull_request` from a fork receives no secrets. Their fixtures are still generated and tested by `test.yaml`, which needs no secrets, so correctness is verified either way. After merge they reach spec-tests with the next merge from an in-repo branch, since each sync replaces the entire generated tree.
+
+Contributing from a branch in `ssvlabs/ssv-spec` is the recommended path: it gets the mirror PR preview while the PR is open.
 
 ---
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -34,7 +34,7 @@ ssv-spec PR merged
 | `test.yaml` | PR, push to `main` | Build, generate, run tests |
 | `sync-spec-tests-pr.yaml` | PR opened / updated / reopened, same-repo only | Sync generated files to spec-tests, create/update PR |
 | `sync-spec-tests-merge.yaml` | Push to `main` | Push final files to spec-tests branch, merge spec-tests PR |
-| `../.github/actions/generate-spec-tests/action.yaml` | (composite, called by all above) | Set up Go, generate JSON fixtures |
+| `../actions/generate-spec-tests/action.yaml` | (composite, called by all above) | Set up Go, generate JSON fixtures |
 
 ---
 
@@ -134,4 +134,4 @@ Set these in **ssv-spec → Settings → Secrets and variables → Actions**.
 |---|---|
 | `SPEC_TESTS_APP_PRIVATE_KEY` | Contents of the `.pem` private key file for the GitHub App |
 
-See the [GitHub App setup guide](https://github.com/ssvlabs/ssv-spec/blob/main/.github/workflows/GITHUB_APP_SETUP.md) for step-by-step instructions on creating the app.
+To create the App: [Registering a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app) with the two permissions above, installed on `spec-tests` only. Its App ID goes in `SPEC_TESTS_APP_ID` and its generated `.pem` private key in `SPEC_TESTS_APP_PRIVATE_KEY`.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,7 +32,7 @@ ssv-spec PR merged
 | File | Trigger | Purpose |
 |---|---|---|
 | `test.yaml` | PR, push to `main` | Build, generate, run tests |
-| `sync-spec-tests-pr.yaml` | PR opened / updated / reopened | Sync generated files to spec-tests, create/update PR |
+| `sync-spec-tests-pr.yaml` | PR opened / updated / reopened, same-repo only | Sync generated files to spec-tests, create/update PR |
 | `sync-spec-tests-merge.yaml` | Push to `main` | Push final files to spec-tests branch, merge spec-tests PR |
 | `../.github/actions/generate-spec-tests/action.yaml` | (composite, called by all above) | Set up Go, generate JSON fixtures |
 
@@ -88,6 +88,12 @@ Runs on every push to `main`.
 5. Verify that matching branch exists in `spec-tests` (created by the PR workflow)
 6. Push a final sync commit to that branch if anything changed
 7. Look up the open spec-tests PR for that branch, merge it, delete the branch
+
+---
+
+### Fork PRs
+
+Fork PRs get no mirror branch or mirror PR while open, because `pull_request` from a fork receives no secrets. Their fixtures are still generated and tested by `test.yaml`, which needs no secrets, so correctness is verified. After merge, `sync-spec-tests-merge.yaml` pushes their fixtures straight to the `spec-tests` base branch. Contributing from a branch in `ssvlabs/ssv-spec` is the recommended path: it gets the mirror PR preview while the PR is open.
 
 ---
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Every PR to this repo automatically keeps a matching branch and PR open in the [spec-tests](https://github.com/ssvlabs/spec-tests) repository, populated with freshly generated JSON test fixtures. When the ssv-spec PR is merged, the spec-tests PR is finalized and merged automatically.
+Every PR from a branch in this repo automatically keeps a matching branch and PR open in the [spec-tests](https://github.com/ssvlabs/spec-tests) repository, populated with freshly generated JSON test fixtures. When the ssv-spec PR is merged, the spec-tests PR is finalized and merged automatically. Fork PRs are excluded — see [Fork PRs](#fork-prs).
 
 ```
 ssv-spec PR opened/updated
@@ -93,7 +93,9 @@ Runs on every push to `main`.
 
 ### Fork PRs
 
-Fork PRs get no mirror branch or mirror PR while open, because `pull_request` from a fork receives no secrets. Their fixtures are still generated and tested by `test.yaml`, which needs no secrets, so correctness is verified either way. After merge they reach spec-tests with the next merge from an in-repo branch, since each sync replaces the entire generated tree.
+Fork PRs get no mirror branch or mirror PR while open, because `pull_request` from a fork receives no secrets. Their fixtures are still generated and tested by `test.yaml`, which needs no secrets, so correctness is verified either way.
+
+After merge, their fixtures reach spec-tests with the next in-repo merge **that has a mirror branch** — each sync replaces the whole generated tree, so it carries the fork's changes along. The gap: an in-repo PR whose own fixtures match spec-tests never pushes a mirror branch, and if such a PR merges next, its merge run finds no mirror branch, sees the fork's fixture diff, and fails loudly rather than pushing. The sync then completes on the following in-repo merge that does have one.
 
 Contributing from a branch in `ssvlabs/ssv-spec` is the recommended path: it gets the mirror PR preview while the PR is open.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Every PR from a branch in this repo automatically keeps a matching branch and PR open in the [spec-tests](https://github.com/ssvlabs/spec-tests) repository, populated with freshly generated JSON test fixtures. When the ssv-spec PR is merged, the spec-tests PR is finalized and merged automatically. Fork PRs are excluded — see [Fork PRs](#fork-prs).
+Every PR from a branch in this repo whose fixtures differ from `spec-tests` automatically keeps a matching branch and PR open in the [spec-tests](https://github.com/ssvlabs/spec-tests) repository, populated with freshly generated JSON test fixtures. When the ssv-spec PR is merged, the spec-tests PR is finalized and merged automatically. Fork PRs are excluded — see [Fork PRs](#fork-prs).
 
 ```
 ssv-spec PR opened/updated

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -38,6 +38,21 @@ ssv-spec PR merged
 
 ---
 
+## Running Locally
+
+The JSON fixtures are no longer committed to this repo — they are generated into a **sibling** `spec-tests` directory, so generation must run before the tests:
+
+```console
+foo@bar:~/ssv-spec$ go generate ./...   # or: make generate-jsons
+foo@bar:~/ssv-spec$ make test
+```
+
+Fixtures resolve to `<parent-of-ssv-spec>/spec-tests/<module>` (`qbft`, `ssv`, `types`), created automatically by `go generate`. A fresh clone that runs `make test` first will fail — `make test` does not depend on `generate-jsons`.
+
+> **Multiple checkouts:** the path is derived from the repo root's parent and is not namespaced per checkout, so two clones or worktrees sharing a parent directory also share one `spec-tests` and overwrite each other's output. Give each checkout its own parent directory.
+
+---
+
 ## Workflows in Detail
 
 ### `test.yaml`

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: 1.22.x
 
@@ -22,7 +22,7 @@ jobs:
         run: go get -v -t -d ./...
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.12.2
           args: -v ./...

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9.1.0
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 60
           days-before-close: -1

--- a/.github/workflows/sync-spec-tests-merge.yaml
+++ b/.github/workflows/sync-spec-tests-merge.yaml
@@ -78,6 +78,25 @@ jobs:
             exit 1
           fi
 
+          # PR_HEAD_REF flows into `git checkout -B`, `git push --force` and
+          # `gh pr list --head` below. It is a bare branch name with no fork
+          # owner, so a fork PR opened from the fork's default branch yields
+          # `main` — and `origin/main` always exists, so the "mirror branch
+          # missing" check cannot catch it. Enforce the same shape and
+          # protected-name rules as sync-spec-tests-pr.yaml before it is used.
+          if ! [[ "${PR_HEAD_REF}" =~ ^[A-Za-z0-9._/-]+$ ]] \
+            || [[ "${PR_HEAD_REF}" == -* ]] \
+            || [[ "${PR_HEAD_REF}" == *..* ]] \
+            || [[ "${PR_HEAD_REF}" == "HEAD" ]]; then
+            echo "Refusing to sync: unsafe branch name '${PR_HEAD_REF}'" >&2
+            exit 1
+          fi
+
+          if [ "${PR_HEAD_REF}" = "main" ] || [ "${PR_HEAD_REF}" = "master" ]; then
+            echo "Refusing to sync: branch name '${PR_HEAD_REF}' would overwrite a protected branch in ${SPEC_TESTS_REPO}" >&2
+            exit 1
+          fi
+
           echo "number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
           echo "head-ref=${PR_HEAD_REF}" >> "${GITHUB_OUTPUT}"
           echo "base-ref=${PR_BASE_REF}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/sync-spec-tests-merge.yaml
+++ b/.github/workflows/sync-spec-tests-merge.yaml
@@ -117,9 +117,10 @@ jobs:
           echo "base-ref=${PR_BASE_REF}" >> "${GITHUB_OUTPUT}"
           echo "is-fork=${IS_FORK}" >> "${GITHUB_OUTPUT}"
 
-      # Fork PRs never got a mirror branch (the PR sync workflow skips them);
-      # their fixtures reach spec-tests with the next same-repo merge, since
-      # each sync below replaces the whole generated tree.
+      # Fork PRs never got a mirror branch (the PR sync workflow skips them),
+      # so there is nothing here to finalize. Their fixtures land with a later
+      # in-repo merge that does have a mirror branch — each sync below replaces
+      # the whole generated tree. See "Fork PRs" in README.md for the gap.
       - name: Push final generated files to spec-tests branch
         if: steps.find-ssv-pr.outputs.is-fork == 'false'
         env:

--- a/.github/workflows/sync-spec-tests-merge.yaml
+++ b/.github/workflows/sync-spec-tests-merge.yaml
@@ -66,11 +66,12 @@ jobs:
           # Resolve the ssv-spec PR that introduced this merge commit (head branch name)
           # Uses GITHUB_TOKEN which is scoped to ssv-spec
           PR_INFO=$(gh api "repos/${{ github.repository }}/commits/${GITHUB_SHA}/pulls" \
-            --jq '.[0] | {number: (.number // empty), head_ref: (.head.ref // empty), base_ref: (.base.ref // empty)}' \
+            --jq '.[0] | {number: (.number // empty), head_ref: (.head.ref // empty), base_ref: (.base.ref // empty), head_repo: (.head.repo.full_name // empty)}' \
             2>/dev/null || echo "{}")
           PR_NUMBER=$(echo "${PR_INFO}" | jq -r '.number // empty')
           PR_HEAD_REF=$(echo "${PR_INFO}" | jq -r '.head_ref // empty')
           PR_BASE_REF=$(echo "${PR_INFO}" | jq -r '.base_ref // empty')
+          PR_HEAD_REPO=$(echo "${PR_INFO}" | jq -r '.head_repo // empty')
 
           if [ -z "${PR_NUMBER}" ] || [ -z "${PR_HEAD_REF}" ]; then
             echo "No PR found for commit ${GITHUB_SHA} in ${{ github.repository }}." >&2
@@ -97,15 +98,24 @@ jobs:
             exit 1
           fi
 
+          # Empty head_repo (API quirk or same-repo omission) preserves today's
+          # behavior: treated as NOT a fork.
+          IS_FORK=false
+          if [ -n "${PR_HEAD_REPO}" ] && [ "${PR_HEAD_REPO}" != "${{ github.repository }}" ]; then
+            IS_FORK=true
+          fi
+
           echo "number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
           echo "head-ref=${PR_HEAD_REF}" >> "${GITHUB_OUTPUT}"
           echo "base-ref=${PR_BASE_REF}" >> "${GITHUB_OUTPUT}"
+          echo "is-fork=${IS_FORK}" >> "${GITHUB_OUTPUT}"
 
       - name: Push final generated files to spec-tests branch
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_HEAD_REF: ${{ steps.find-ssv-pr.outputs.head-ref }}
           PR_BASE_REF: ${{ steps.find-ssv-pr.outputs.base-ref }}
+          IS_FORK: ${{ steps.find-ssv-pr.outputs.is-fork }}
           BOT_NAME: ${{ steps.bot-identity.outputs.name }}
           BOT_EMAIL: ${{ steps.bot-identity.outputs.email }}
         run: |
@@ -144,6 +154,24 @@ jobs:
             cp -r "${GENERATED_DIR}/." .
             git add -A
           }
+
+          # Fork PRs never got a mirror branch (the PR sync workflow skips
+          # forks), so there is no mirror branch or mirror PR to touch. Push
+          # straight to the base branch instead — a plain fast-forward push,
+          # not the force-push-to-main hazard the PR_HEAD_REF validation above guards against.
+          if [ "${IS_FORK}" = "true" ]; then
+            git checkout -B "${RESOLVED_BASE}" "origin/${RESOLVED_BASE}"
+            sync_generated_paths
+
+            if git diff --cached --quiet; then
+              echo "No changes to sync to spec-tests branch '${RESOLVED_BASE}' (fork PR)"
+              exit 0
+            fi
+
+            git commit -m "sync: final update from ssv-spec ${GITHUB_SHA} (fork PR)"
+            git push origin "${RESOLVED_BASE}"
+            exit 0
+          fi
 
           # The spec-tests branch has the same name as the ssv-spec PR branch.
           if ! git show-ref --verify --quiet "refs/remotes/origin/${PR_HEAD_REF}"; then

--- a/.github/workflows/sync-spec-tests-merge.yaml
+++ b/.github/workflows/sync-spec-tests-merge.yaml
@@ -79,30 +79,35 @@ jobs:
             exit 1
           fi
 
+          # Empty head_repo (API quirk or same-repo omission) preserves today's
+          # behavior: treated as NOT a fork.
+          IS_FORK=false
+          if [ -n "${PR_HEAD_REPO}" ] && [ "${PR_HEAD_REPO}" != "${{ github.repository }}" ]; then
+            IS_FORK=true
+          fi
+
           # PR_HEAD_REF flows into `git checkout -B`, `git push --force` and
           # `gh pr list --head` below. It is a bare branch name with no fork
           # owner, so a fork PR opened from the fork's default branch yields
           # `main` — and `origin/main` always exists, so the "mirror branch
           # missing" check cannot catch it. Enforce the same shape and
           # protected-name rules as sync-spec-tests-pr.yaml before it is used.
-          if ! [[ "${PR_HEAD_REF}" =~ ^[A-Za-z0-9._/-]+$ ]] \
-            || [[ "${PR_HEAD_REF}" == -* ]] \
-            || [[ "${PR_HEAD_REF}" == *..* ]] \
-            || [[ "${PR_HEAD_REF}" == "HEAD" ]]; then
-            echo "Refusing to sync: unsafe branch name '${PR_HEAD_REF}'" >&2
-            exit 1
-          fi
+          # Same-repo only: for fork PRs, PR_HEAD_REF never reaches
+          # `git checkout -B`, `git push` or `gh pr list --head` — the fork path
+          # syncs to the base branch instead.
+          if [ "${IS_FORK}" != "true" ]; then
+            if ! [[ "${PR_HEAD_REF}" =~ ^[A-Za-z0-9._/-]+$ ]] \
+              || [[ "${PR_HEAD_REF}" == -* ]] \
+              || [[ "${PR_HEAD_REF}" == *..* ]] \
+              || [[ "${PR_HEAD_REF}" == "HEAD" ]]; then
+              echo "Refusing to sync: unsafe branch name '${PR_HEAD_REF}'" >&2
+              exit 1
+            fi
 
-          if [ "${PR_HEAD_REF}" = "main" ] || [ "${PR_HEAD_REF}" = "master" ]; then
-            echo "Refusing to sync: branch name '${PR_HEAD_REF}' would overwrite a protected branch in ${SPEC_TESTS_REPO}" >&2
-            exit 1
-          fi
-
-          # Empty head_repo (API quirk or same-repo omission) preserves today's
-          # behavior: treated as NOT a fork.
-          IS_FORK=false
-          if [ -n "${PR_HEAD_REPO}" ] && [ "${PR_HEAD_REPO}" != "${{ github.repository }}" ]; then
-            IS_FORK=true
+            if [ "${PR_HEAD_REF}" = "main" ] || [ "${PR_HEAD_REF}" = "master" ]; then
+              echo "Refusing to sync: branch name '${PR_HEAD_REF}' would overwrite a protected branch in ${SPEC_TESTS_REPO}" >&2
+              exit 1
+            fi
           fi
 
           echo "number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/sync-spec-tests-merge.yaml
+++ b/.github/workflows/sync-spec-tests-merge.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       SPEC_TESTS_REPO: ${{ vars.SPEC_TESTS_REPO }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate required variables
         run: |
@@ -33,7 +33,7 @@ jobs:
         run: echo "name=${SPEC_TESTS_REPO##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Get GitHub App token
-        uses: actions/create-github-app-token@v3.0.0
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ vars.SPEC_TESTS_APP_ID }}

--- a/.github/workflows/sync-spec-tests-merge.yaml
+++ b/.github/workflows/sync-spec-tests-merge.yaml
@@ -115,12 +115,15 @@ jobs:
           echo "base-ref=${PR_BASE_REF}" >> "${GITHUB_OUTPUT}"
           echo "is-fork=${IS_FORK}" >> "${GITHUB_OUTPUT}"
 
+      # Fork PRs never got a mirror branch (the PR sync workflow skips them);
+      # their fixtures reach spec-tests with the next same-repo merge, since
+      # each sync below replaces the whole generated tree.
       - name: Push final generated files to spec-tests branch
+        if: steps.find-ssv-pr.outputs.is-fork != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_HEAD_REF: ${{ steps.find-ssv-pr.outputs.head-ref }}
           PR_BASE_REF: ${{ steps.find-ssv-pr.outputs.base-ref }}
-          IS_FORK: ${{ steps.find-ssv-pr.outputs.is-fork }}
           BOT_NAME: ${{ steps.bot-identity.outputs.name }}
           BOT_EMAIL: ${{ steps.bot-identity.outputs.email }}
         run: |
@@ -159,24 +162,6 @@ jobs:
             cp -r "${GENERATED_DIR}/." .
             git add -A
           }
-
-          # Fork PRs never got a mirror branch (the PR sync workflow skips
-          # forks), so there is no mirror branch or mirror PR to touch. Push
-          # straight to the base branch instead — a plain fast-forward push,
-          # not the force-push-to-main hazard the PR_HEAD_REF validation above guards against.
-          if [ "${IS_FORK}" = "true" ]; then
-            git checkout -B "${RESOLVED_BASE}" "origin/${RESOLVED_BASE}"
-            sync_generated_paths
-
-            if git diff --cached --quiet; then
-              echo "No changes to sync to spec-tests branch '${RESOLVED_BASE}' (fork PR)"
-              exit 0
-            fi
-
-            git commit -m "sync: final update from ssv-spec ${GITHUB_SHA} (fork PR)"
-            git push origin "${RESOLVED_BASE}"
-            exit 0
-          fi
 
           # The spec-tests branch has the same name as the ssv-spec PR branch.
           if ! git show-ref --verify --quiet "refs/remotes/origin/${PR_HEAD_REF}"; then

--- a/.github/workflows/sync-spec-tests-merge.yaml
+++ b/.github/workflows/sync-spec-tests-merge.yaml
@@ -66,7 +66,7 @@ jobs:
           # Resolve the ssv-spec PR that introduced this merge commit (head branch name)
           # Uses GITHUB_TOKEN which is scoped to ssv-spec
           PR_INFO=$(gh api "repos/${{ github.repository }}/commits/${GITHUB_SHA}/pulls" \
-            --jq '.[0] | {number: (.number // empty), head_ref: (.head.ref // empty), base_ref: (.base.ref // empty), head_repo: (.head.repo.full_name // empty)}' \
+            --jq '.[0] | {number: (.number // empty), head_ref: (.head.ref // empty), base_ref: (.base.ref // empty), head_repo: (.head.repo.full_name // "")}' \
             2>/dev/null || echo "{}")
           PR_NUMBER=$(echo "${PR_INFO}" | jq -r '.number // empty')
           PR_HEAD_REF=$(echo "${PR_INFO}" | jq -r '.head_ref // empty')
@@ -79,11 +79,13 @@ jobs:
             exit 1
           fi
 
-          # Empty head_repo (API quirk or same-repo omission) preserves today's
-          # behavior: treated as NOT a fork.
-          IS_FORK=false
-          if [ -n "${PR_HEAD_REPO}" ] && [ "${PR_HEAD_REPO}" != "${{ github.repository }}" ]; then
-            IS_FORK=true
+          # Same-repo PRs always report head.repo; it is null only when the head
+          # repository is gone (deleted fork). Unknown therefore means "not this
+          # repo", and skipping the sync is the safe reading — there is no mirror
+          # branch to finalize and nothing to push.
+          IS_FORK=true
+          if [ "${PR_HEAD_REPO}" = "${{ github.repository }}" ]; then
+            IS_FORK=false
           fi
 
           # PR_HEAD_REF flows into `git checkout -B`, `git push --force` and
@@ -119,7 +121,7 @@ jobs:
       # their fixtures reach spec-tests with the next same-repo merge, since
       # each sync below replaces the whole generated tree.
       - name: Push final generated files to spec-tests branch
-        if: steps.find-ssv-pr.outputs.is-fork != 'true'
+        if: steps.find-ssv-pr.outputs.is-fork == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_HEAD_REF: ${{ steps.find-ssv-pr.outputs.head-ref }}

--- a/.github/workflows/sync-spec-tests-merge.yaml
+++ b/.github/workflows/sync-spec-tests-merge.yaml
@@ -93,8 +93,8 @@ jobs:
           # missing" check cannot catch it. Enforce the same shape and
           # protected-name rules as sync-spec-tests-pr.yaml before it is used.
           # Same-repo only: for fork PRs, PR_HEAD_REF never reaches
-          # `git checkout -B`, `git push` or `gh pr list --head` — the fork path
-          # syncs to the base branch instead.
+          # `git checkout -B`, `git push` or `gh pr list --head`, because the
+          # push step below is skipped for them entirely.
           if [ "${IS_FORK}" != "true" ]; then
             if ! [[ "${PR_HEAD_REF}" =~ ^[A-Za-z0-9._/-]+$ ]] \
               || [[ "${PR_HEAD_REF}" == -* ]] \

--- a/.github/workflows/sync-spec-tests-pr.yaml
+++ b/.github/workflows/sync-spec-tests-pr.yaml
@@ -14,7 +14,11 @@ jobs:
 
   # Runs PR-controlled code (`go generate`). Deliberately holds no spec-tests
   # credentials: its only output is an artifact consumed as data by `sync`.
+  #
+  # Fork PRs get no secrets on `pull_request` anyway, so sync cannot work; they
+  # are synced after merge by sync-spec-tests-merge.yaml instead.
   generate:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -48,6 +52,7 @@ jobs:
   # checked out here, the generated tree is only ever treated as data.
   sync:
     needs: generate
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/sync-spec-tests-pr.yaml
+++ b/.github/workflows/sync-spec-tests-pr.yaml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate required variables
         run: |
@@ -41,7 +41,7 @@ jobs:
         run: tar -czf spec-tests.tar.gz -C "${GITHUB_WORKSPACE}/.." spec-tests
 
       - name: Upload generated spec tests
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spec-tests
           path: spec-tests.tar.gz
@@ -60,7 +60,7 @@ jobs:
       SPEC_TESTS_REPO: ${{ vars.SPEC_TESTS_REPO }}
     steps:
       - name: Download generated spec tests
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: spec-tests
 
@@ -79,7 +79,7 @@ jobs:
         run: echo "name=${SPEC_TESTS_REPO##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Get GitHub App token
-        uses: actions/create-github-app-token@v3.0.0
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ vars.SPEC_TESTS_APP_ID }}

--- a/.github/workflows/sync-spec-tests-pr.yaml
+++ b/.github/workflows/sync-spec-tests-pr.yaml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Both runs force-push the same mirror branch with no ordering, so an older commit's
+# fixtures can land last and leave it stale. Keyed on PR number, not head_ref (collides across forks).
+concurrency:
+  group: sync-spec-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
 
   # Runs PR-controlled code (`go generate`). Deliberately holds no spec-tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate spec tests
         uses: ./.github/actions/generate-spec-tests

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GOLANGCI_LINT_VERSION?=v2.12.2
 
 .PHONY: lint-prepare
 lint-prepare:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s $(GOLANGCI_LINT_VERSION)
+	curl -sfL https://golangci-lint.run/install.sh| sh -s $(GOLANGCI_LINT_VERSION)
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 GOPATH?=$(shell go env GOPATH)
 TEST_PKG?=./...
+# Keep in sync with the version pinned in .github/workflows/lint.yaml
+GOLANGCI_LINT_VERSION?=v2.12.2
 
 .PHONY: lint-prepare
 lint-prepare:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s latest
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s $(GOLANGCI_LINT_VERSION)
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ GOLANGCI_LINT_VERSION?=v2.12.2
 
 .PHONY: lint-prepare
 lint-prepare:
-	curl -sfL https://golangci-lint.run/install.sh| sh -s $(GOLANGCI_LINT_VERSION)
+	@tmp=$$(mktemp) \
+		&& curl -sfL https://golangci-lint.run/install.sh -o "$$tmp" \
+		&& sh "$$tmp" $(GOLANGCI_LINT_VERSION) \
+		&& rm -f "$$tmp"
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -184,3 +184,9 @@ To generate all json spec tests, run:
 foo@bar:~$ go generate ./...
 ```
 Then run all tests
+
+```console
+foo@bar:~$ make test
+```
+
+The generated JSONs are not committed here — they are written to a sibling `spec-tests` directory (`<parent-of-ssv-spec>/spec-tests/<module>`), so `go generate ./...` must run before `make test`. See [.github/workflows/README.md](.github/workflows/README.md#running-locally) for the full local setup, including the caveat about multiple checkouts sharing one `spec-tests` directory.

--- a/qbft/spectest/run_test.go
+++ b/qbft/spectest/run_test.go
@@ -31,7 +31,7 @@ func TestJson(t *testing.T) {
 	basedir, _ := os.Getwd()
 	specTestsDir, err := typescomparable.SpecTestsDirFrom(basedir)
 	if err != nil {
-		panic(err.Error())
+		t.Fatalf("Failed to resolve spec-tests dir: %v", err)
 	}
 	path := filepath.Join(specTestsDir, "tests.json")
 	untypedTests := map[string]interface{}{}

--- a/types/spectest/run_test.go
+++ b/types/spectest/run_test.go
@@ -42,7 +42,7 @@ func TestJson(t *testing.T) {
 	basedir, _ := os.Getwd()
 	specTestsDir, err := comparable.SpecTestsDirFrom(basedir)
 	if err != nil {
-		panic(err.Error())
+		t.Fatalf("Failed to resolve spec-tests dir: %v", err)
 	}
 	path := filepath.Join(specTestsDir, "tests.json")
 	untypedTests := map[string]interface{}{}


### PR DESCRIPTION
Addresses review comments on #610. Targets `spec-test-ci` so the fixes land in that PR.

| Commit | Comment addressed |
|---|---|
| `3002d0052` | Local-run docs: sibling `spec-tests/<module>` layout, generate-before-`make test`, multiple-checkout collision |
| `99f5ced30` | Pin local golangci-lint to the version CI pins (v2.12.2) |
| `fa23e5883` | Use the supported installer — the `master` `install.sh` fails sha256 verification for v2 (same change as #629, plus the pin) |
| `5b53256f2` | Validate `PR_HEAD_REF` in the merge sync before it reaches `git checkout -B` / `git push --force` |
| `1608fb86c` | Concurrency group on the PR sync, keyed on PR number |
| `e5f973ae5`, `f69153349`, `50c07ff0c`, `2db08b6f3`, `59a8536e6` | Fork policy: fork PRs skip the pre-merge sync; the merge sync skips its push step for fork-originated merges |
| `7f4aae97e` | Composite action path in the Files table, dead App-setup link, `t.Fatalf` instead of `panic` in qbft/types spectest |

Not taken, with reasoning in the review threads: extracting the duplicated sync core (the control flow around it is deliberately asymmetric), renaming mirror branches to `ssv-spec-pr-<number>`, and the `workflow_run` restructure for fork PRs.

Two things for whoever merges:
- Confirm no required status check is pinned to `Test / build` — `main` is governed by an org-level ruleset I can't read.
- #629 makes the same installer change and should be closed rather than merged, or the version pin reverts to `latest`.

Every workflow change was reviewed by codex; the review caught a jq `// empty` defect that collapsed the PR lookup for deleted forks, fixed in `59a8536e6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)